### PR TITLE
Fixed total time for showStatus

### DIFF
--- a/lib/task/sfBaseTask.class.php
+++ b/lib/task/sfBaseTask.class.php
@@ -449,6 +449,7 @@ abstract class sfBaseTask extends sfCommandApplicationTask
     // if we go over our bound, just ignore it
     if ($done > $total)
     {
+      $this->statusStartTime = null;
       return;
     }
 
@@ -493,6 +494,7 @@ abstract class sfBaseTask extends sfCommandApplicationTask
     // when done, send a newline
     if ($done == $total)
     {
+      $this->statusStartTime = null;
       echo "\n";
     }
   }


### PR DESCRIPTION
If I use 2 `showStatus` for a task, they use the same `statusStartTime`, so the "elapsed" time for the 2nd is wrong.
