### PR TITLE
Fix error where form cannot be submitted because of post_max_size=0

### DIFF
--- a/lib/validator/sfValidatorSchema.class.php
+++ b/lib/validator/sfValidatorSchema.class.php
@@ -110,7 +110,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
     $errorSchema = new sfValidatorErrorSchema($this);
 
     // check that post_max_size has not been reached
-    if (isset($_SERVER['CONTENT_LENGTH']) && (int) $_SERVER['CONTENT_LENGTH'] > $this->getBytes(ini_get('post_max_size')))
+    if (isset($_SERVER['CONTENT_LENGTH']) && (int) $_SERVER['CONTENT_LENGTH'] > $this->getBytes(ini_get('post_max_size')) && ini_get('post_max_size') != 0)
     {
       $errorSchema->addError(new sfValidatorError($this, 'post_max_size'));
 


### PR DESCRIPTION
Symfony triggers an error on form submission if we set the post_max_size to 0 (to disable the limit)
