### PR TITLE
Add a warning in README about not using this fork for new projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 [![Build Status](https://secure.travis-ci.org/LExpress/symfony1.png?branch=master)](http://travis-ci.org/LExpress/symfony1)
 
+About this version
+------------------
+
+This is a community driven fork of symfony 1, as official support as been [interrupted in November 2012](http://symfony.com/blog/symfony-1-4-end-of-maintenance-what-does-it-mean).
+
+**Please do not use it for new projects: this version is great to improve existing symfony1 applications, but [Symfony2](http://symfony.com/) is the way to go today.**
+All the enhancements and BC breaks are listed in [WHATS_NEW.md](https://github.com/LExpress/symfony1/blob/master/WHATS_NEW.md), this include:
+
+- Composer support
+- [DIC](https://github.com/LExpress/symfony1/wiki/ServiceContainer)
+- new features like `sfAction::renderJson` or `sfValidatorIp`
+- some tickets fixed from the symfony trac
+- ...
+
+About symfony
+-------------
+
 Symfony is a complete framework designed to optimize the development of web applications by way of several key features.
 For starters, it separates a web application's business rules, server logic, and presentation views.
 It contains numerous tools and classes aimed at shortening the development time of a complex web application.
@@ -40,4 +57,4 @@ Read the official [symfony1 documentation](http://symfony.com/legacy)
 Contributing
 ------------
 
-You can let pull requests or create an issue.
+You can send pull requests or create an issue.


### PR DESCRIPTION
Everything is in the title,
having this fork tagged as 1.5 is great, as there is some BC breaks,
but I think it should not been used for new projects, same as the official symfony1 - as lot's of plugins are abandoned (maybe even not compatible with the changes here) etc...
