### PR TITLE
Change find_caller to include sfTestFunctionalBase and sfTester

### DIFF
--- a/lib/vendor/lime/lime.php
+++ b/lib/vendor/lime/lime.php
@@ -530,13 +530,18 @@ class lime_test
     $this->results['tests'][$this->test_nb]['error'] = implode("\n", $errors);
   }
 
+  private function is_test_object($object)
+  {
+    return $object instanceof lime_test || $object instanceof sfTestFunctionalBase || $object instanceof sfTester;
+  }
+
   protected function find_caller($traces)
   {
     // find the first call to a method of an object that is an instance of lime_test
     $t = array_reverse($traces);
     foreach ($t as $trace)
     {
-      if (isset($trace['object']) && $trace['object'] instanceof lime_test)
+      if (isset($trace['object']) && $this->is_test_object($trace['object']))
       {
         return array($trace['file'], $trace['line']);
       }


### PR DESCRIPTION
This will result in the correct filename and linenumber when outputting XML for functional tests.

Normally this would output something like:
`<testsuite name="sfTestFunctionalBase.class" file="vendor/lexpress/symfony1/lib/test/sfTestFunctionalBase.class.php" failures="0" errors="0" skipped="0" tests="66" assertions="66">`

With this fix it will be:
`<testsuite name="userActionsTest" file=test/functional/api2/userActionsTest.php" failures="0" errors="0" skipped="0" tests="66" assertions="66">`
