### PR TITLE
Fixbug, refact. BC on sfCacheSessionStorage

### DIFF
--- a/lib/storage/sfCacheSessionStorage.class.php
+++ b/lib/storage/sfCacheSessionStorage.class.php
@@ -129,14 +129,21 @@ class sfCacheSessionStorage extends sfStorage
       {
         $this->data = array();
       }
-      elseif (is_array($raw))
-      {
-        // probably an old cached value (BC)
-        $this->data = $raw;
-      }
       else
       {
-        $this->data = unserialize($raw);
+        $data = @unserialize($raw);
+        // We test 'b:0' special case, because such a string would result
+        // in $data being === false, while raw is serialized
+        // see http://stackoverflow.com/questions/1369936/check-to-see-if-a-string-is-serialized
+        if ( $raw === 'b:0;' || $data !== false)
+        {
+          $this->data = $data;
+        }
+        else
+        {
+          // Probably an old cached value (BC)
+          $this->data = $raw;
+        }
       }
 
       if(sfConfig::get('sf_logging_enabled'))


### PR DESCRIPTION
Correction d'un bug de compatibilité entre la gestion de sessions en memcache via symfony 1.4, et cette nouvelle version 1.5. 
La rétrocomp' était mal gérée, et menait à des affectations par référence depuis des offset de tableau (erreur : Cannot create references to/from string offsets nor overloaded objects ). Ce fix corrige l'erreur et assure la rétrocomp' :)
