### PR TITLE
Fix sfAutoload

### DIFF
--- a/lib/autoload/sfAutoload.class.php
+++ b/lib/autoload/sfAutoload.class.php
@@ -138,7 +138,10 @@ class sfAutoload
 
     $file = $configuration->getConfigCache()->checkConfig('config/autoload.yml');
 
-    $this->classes = include($file);
+    if (file_exists($file))
+    {
+      $this->classes = include($file);
+    }
 
     foreach ($this->overriden as $class => $path)
     {


### PR DESCRIPTION
Dans la continuité du précédent PR, correction du bug suivant : 

```
PHP Warning:  include(/var/www/project/cache/frontend/dev/config/config_autoload.yml.php): failed to open stream: No such file or directory in /var/www/project/lib/vendor/symfony-1.5/lib/autoload/sfAutoload.class.php on line 141
```
