### PR TITLE
Add an option to test:all task to show full output

### DIFF
--- a/lib/task/symfony/lime_symfony.php
+++ b/lib/task/symfony/lime_symfony.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */

--- a/lib/task/test/sfLimeHarness.class.php
+++ b/lib/task/test/sfLimeHarness.class.php
@@ -11,13 +11,26 @@ class sfLimeHarness extends lime_harness
   {
     foreach ($plugins as $plugin)
     {
-      $this->plugins[$plugin->getRootDir().DIRECTORY_SEPARATOR.'test'.DIRECTORY_SEPARATOR] = '['.preg_replace('/Plugin$/i', '', $plugin->getName()).'] ';
+      $pluginDir = $plugin->getRootDir().DIRECTORY_SEPARATOR.'test'.DIRECTORY_SEPARATOR;
+
+      $this->plugins[$pluginDir] = '['.preg_replace('/Plugin$/i', '', $plugin->getName()).'] ';
+
+      if (true === $this->full_output)
+      {
+        $this->plugins[$pluginDir] .= $pluginDir;
+      }
     }
   }
 
   protected function get_relative_file($file)
   {
     $file = strtr($file, $this->plugins);
+
+    if (true === $this->full_output)
+    {
+      return $file;
+    }
+
     return str_replace(DIRECTORY_SEPARATOR, '/', str_replace(array(realpath($this->base_dir).DIRECTORY_SEPARATOR, $this->extension), '', $file));
   }
 }

--- a/lib/task/test/sfTestAllTask.class.php
+++ b/lib/task/test/sfTestAllTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -25,6 +25,7 @@ class sfTestAllTask extends sfTestBaseTask
   {
     $this->addOptions(array(
       new sfCommandOption('only-failed', 'f', sfCommandOption::PARAMETER_NONE, 'Only run tests that failed last time'),
+      new sfCommandOption('full-output', 'o', sfCommandOption::PARAMETER_NONE, 'Display full path for the test'),
       new sfCommandOption('xml', null, sfCommandOption::PARAMETER_REQUIRED, 'The file name for the JUnit compatible XML log file'),
     ));
 
@@ -62,6 +63,11 @@ The task can output a JUnit compatible XML log file with the [--xml|COMMENT]
 options:
 
   [./symfony test:all --xml=log.xml|INFO]
+
+If you want to display full path for each test in output, add the option
+[--full-output|COMMENT] or [-o|COMMENT] :
+
+  [./symfony test:all --full-output|INFO]
 EOF;
   }
 
@@ -76,6 +82,7 @@ EOF;
       'force_colors' => isset($options['color']) && $options['color'],
       'verbose'      => isset($options['trace']) && $options['trace'],
     ));
+    $h->full_output = $options['full-output'] ? true : false;
     $h->addPlugins(array_map(array($this->configuration, 'getPluginConfiguration'), $this->configuration->getPlugins()));
     $h->base_dir = sfConfig::get('sf_test_dir');
 

--- a/lib/vendor/lime/lime.php
+++ b/lib/vendor/lime/lime.php
@@ -816,6 +816,7 @@ class lime_harness extends lime_registration
   public $php_cli = null;
   public $stats   = array();
   public $output  = null;
+  public $full_output = false;
 
   public function __construct($options = array())
   {
@@ -978,7 +979,14 @@ EOF
         }
       }
 
-      $this->output->echoln(sprintf('%s%s%s', substr($relative_file, -min(67, strlen($relative_file))), str_repeat('.', 70 - min(67, strlen($relative_file))), $stats['status']));
+      if (true === $this->full_output)
+      {
+        $this->output->echoln(sprintf('%s%s%s', $relative_file, '.....', $stats['status']));
+      }
+      else
+      {
+        $this->output->echoln(sprintf('%s%s%s', substr($relative_file, -min(67, strlen($relative_file))), str_repeat('.', 70 - min(67, strlen($relative_file))), $stats['status']));
+      }
 
       if ('dubious' == $stats['status'])
       {


### PR DESCRIPTION
The variable `full_output` in lime_harness class will allow `test:all` task to output full path of the current test.

Before:

```
[sfMyAwesomePlugin] functional/sfMyAwesomePluginServiceTest..............ok
```

After:

```
[sfMyAwesomePlugin] /var/www/htdocs/test/sfMyAwesomePlugin/functional/sfMyAwesomePluginServiceTest.php..ok
```

This is more "strict" and less straight but more efficient to copy/paste the test and relaunch it.
