### PR TITLE
replace dirname(__FILE__) by __DIR__

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,5 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/lib/autoload/sfCoreAutoload.class.php';
+require_once __DIR__.'/lib/autoload/sfCoreAutoload.class.php';
 
 sfCoreAutoload::register();

--- a/data/bin/changelog.php
+++ b/data/bin/changelog.php
@@ -17,7 +17,7 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id$
  */
-require_once dirname(__FILE__).'/../../lib/task/sfFilesystem.class.php';
+require_once __DIR__.'/../../lib/task/sfFilesystem.class.php';
 
 if (!isset($argv[1]))
 {

--- a/data/bin/release.php
+++ b/data/bin/release.php
@@ -17,10 +17,10 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id$
  */
-require_once(dirname(__FILE__).'/../../lib/exception/sfException.class.php');
-require_once(dirname(__FILE__).'/../../lib/task/sfFilesystem.class.php');
-require_once(dirname(__FILE__).'/../../lib/util/sfFinder.class.php');
-require_once(dirname(__FILE__).'/../../lib/vendor/lime/lime.php');
+require_once(__DIR__.'/../../lib/exception/sfException.class.php');
+require_once(__DIR__.'/../../lib/task/sfFilesystem.class.php');
+require_once(__DIR__.'/../../lib/util/sfFinder.class.php');
+require_once(__DIR__.'/../../lib/vendor/lime/lime.php');
 
 if (!isset($argv[1]))
 {

--- a/data/bin/sandbox_installer.php
+++ b/data/bin/sandbox_installer.php
@@ -1,12 +1,12 @@
 <?php
 
-$this->installDir(dirname(__FILE__).'/sandbox_skeleton');
+$this->installDir(__DIR__.'/sandbox_skeleton');
 
 $this->logSection('install', 'add symfony CLI for Windows users');
-$this->getFilesystem()->copy(dirname(__FILE__).'/symfony.bat', sfConfig::get('sf_root_dir').'/symfony.bat');
+$this->getFilesystem()->copy(__DIR__.'/symfony.bat', sfConfig::get('sf_root_dir').'/symfony.bat');
 
 $this->logSection('install', 'add LICENSE');
-$this->getFilesystem()->copy(dirname(__FILE__).'/../../LICENSE', sfConfig::get('sf_root_dir').'/LICENSE');
+$this->getFilesystem()->copy(__DIR__.'/../../LICENSE', sfConfig::get('sf_root_dir').'/LICENSE');
 
 $this->logSection('install', 'default to sqlite');
 $this->runTask('configure:database', sprintf("'sqlite:%s/sandbox.db'", sfConfig::get('sf_data_dir')));

--- a/data/bin/symfony
+++ b/data/bin/symfony
@@ -17,10 +17,10 @@ if (file_exists('config/ProjectConfiguration.class.php'))
 }
 else
 {
-  if (is_readable(dirname(__FILE__).'/../../lib/autoload/sfCoreAutoload.class.php'))
+  if (is_readable(__DIR__.'/../../lib/autoload/sfCoreAutoload.class.php'))
   {
     // SVN
-    $dir = realpath(dirname(__FILE__).'/../../lib');
+    $dir = realpath(__DIR__.'/../../lib');
   }
   else
   {

--- a/lib/autoload/sfCoreAutoload.class.php
+++ b/lib/autoload/sfCoreAutoload.class.php
@@ -36,7 +36,7 @@ class sfCoreAutoload
 
   protected function __construct()
   {
-    $this->baseDir = realpath(dirname(__FILE__).'/..');
+    $this->baseDir = realpath(__DIR__.'/..');
   }
 
   /**
@@ -141,7 +141,7 @@ class sfCoreAutoload
    */
   static public function make()
   {
-    $libDir = str_replace(DIRECTORY_SEPARATOR, '/', realpath(dirname(__FILE__).DIRECTORY_SEPARATOR.'..'));
+    $libDir = str_replace(DIRECTORY_SEPARATOR, '/', realpath(__DIR__.DIRECTORY_SEPARATOR.'..'));
     require_once $libDir.'/util/sfFinder.class.php';
 
     $files = sfFinder::type('file')

--- a/lib/cache/sfCache.class.php
+++ b/lib/cache/sfCache.class.php
@@ -57,7 +57,7 @@ abstract class sfCache
     $this->options = array_merge(array(
       'automatic_cleaning_factor' => 1000,
       'lifetime'                  => 86400,
-      'prefix'                    => md5(dirname(__FILE__)),
+      'prefix'                    => md5(__DIR__),
     ), $options);
 
     $this->options['prefix'] .= self::SEPARATOR;

--- a/lib/command/cli.php
+++ b/lib/command/cli.php
@@ -9,15 +9,15 @@
  */
 
 // Try autoloading using composer if available.
-if (!file_exists($autoload = dirname(__FILE__).'/../../../../autoload.php'))
+if (!file_exists($autoload = __DIR__.'/../../../../autoload.php'))
 {
-  $autoload = dirname(__FILE__).'/../../autoload.php';
+  $autoload = __DIR__.'/../../autoload.php';
 }
 
 // Fall back to classic Symfony loading
 if (!file_exists($autoload))
 {
-  require_once(dirname(__FILE__).'/../autoload/sfCoreAutoload.class.php');
+  require_once(__DIR__.'/../autoload/sfCoreAutoload.class.php');
   sfCoreAutoload::register();
 }
 else
@@ -30,7 +30,7 @@ try
   $dispatcher = new sfEventDispatcher();
   $logger = new sfCommandLogger($dispatcher);
 
-  $application = new sfSymfonyCommandApplication($dispatcher, null, array('symfony_lib_dir' => realpath(dirname(__FILE__).'/..')));
+  $application = new sfSymfonyCommandApplication($dispatcher, null, array('symfony_lib_dir' => realpath(__DIR__.'/..')));
   $statusCode = $application->run();
 }
 catch (Exception $e)

--- a/lib/config/sfProjectConfiguration.class.php
+++ b/lib/config/sfProjectConfiguration.class.php
@@ -45,7 +45,7 @@ class sfProjectConfiguration
     }
 
     $this->rootDir = null === $rootDir ? self::guessRootDir() : realpath($rootDir);
-    $this->symfonyLibDir = realpath(dirname(__FILE__).'/..');
+    $this->symfonyLibDir = realpath(__DIR__.'/..');
     $this->dispatcher = null === $dispatcher ? new sfEventDispatcher() : $dispatcher;
 
     ini_set('magic_quotes_runtime', 'off');

--- a/lib/controller/default/templates/disabledSuccess.php
+++ b/lib/controller/default/templates/disabledSuccess.php
@@ -1,4 +1,4 @@
-<?php decorate_with(dirname(__FILE__).'/defaultLayout.php') ?>
+<?php decorate_with(__DIR__.'/defaultLayout.php') ?>
 
 <div class="sfTMessageContainer sfTAlert"> 
   <?php echo image_tag('/sf/sf_default/images/icons/disabled48.png', array('alt' => 'module disabled', 'class' => 'sfTMessageIcon', 'size' => '48x48')) ?>

--- a/lib/controller/default/templates/error404Success.php
+++ b/lib/controller/default/templates/error404Success.php
@@ -1,4 +1,4 @@
-<?php decorate_with(dirname(__FILE__).'/defaultLayout.php') ?>
+<?php decorate_with(__DIR__.'/defaultLayout.php') ?>
 
 <div class="sfTMessageContainer sfTAlert"> 
   <?php echo image_tag('/sf/sf_default/images/icons/cancel48.png', array('alt' => 'page not found', 'class' => 'sfTMessageIcon', 'size' => '48x48')) ?>

--- a/lib/controller/default/templates/indexSuccess.php
+++ b/lib/controller/default/templates/indexSuccess.php
@@ -1,4 +1,4 @@
-<?php decorate_with(dirname(__FILE__).'/defaultLayout.php') ?>
+<?php decorate_with(__DIR__.'/defaultLayout.php') ?>
 
 <div class="sfTMessageContainer sfTMessage"> 
   <?php echo image_tag('/sf/sf_default/images/icons/ok48.png', array('alt' => 'ok', 'class' => 'sfTMessageIcon', 'size' => '48x48')) ?>

--- a/lib/controller/default/templates/loginSuccess.php
+++ b/lib/controller/default/templates/loginSuccess.php
@@ -1,4 +1,4 @@
-<?php decorate_with(dirname(__FILE__).'/defaultLayout.php') ?>
+<?php decorate_with(__DIR__.'/defaultLayout.php') ?>
 
 <div class="sfTMessageContainer sfTLock"> 
   <?php echo image_tag('/sf/sf_default/images/icons/lock48.png', array('alt' => 'login required', 'class' => 'sfTMessageIcon', 'size' => '48x48')) ?>

--- a/lib/controller/default/templates/moduleSuccess.php
+++ b/lib/controller/default/templates/moduleSuccess.php
@@ -1,4 +1,4 @@
-<?php decorate_with(dirname(__FILE__).'/defaultLayout.php') ?>
+<?php decorate_with(__DIR__.'/defaultLayout.php') ?>
 
 <div class="sfTMessageContainer sfTMessage"> 
   <?php echo image_tag('/sf/sf_default/images/icons/ok48.png', array('alt' => 'module created', 'class' => 'sfTMessageIcon', 'size' => '48x48')) ?>

--- a/lib/controller/default/templates/secureSuccess.php
+++ b/lib/controller/default/templates/secureSuccess.php
@@ -1,4 +1,4 @@
-<?php decorate_with(dirname(__FILE__).'/defaultLayout.php') ?>
+<?php decorate_with(__DIR__.'/defaultLayout.php') ?>
 
 <div class="sfTMessageContainer sfTLock"> 
   <?php echo image_tag('/sf/sf_default/images/icons/lock48.png', array('alt' => 'credentials required', 'class' => 'sfTMessageIcon', 'size' => '48x48')) ?>

--- a/lib/exception/sfException.class.php
+++ b/lib/exception/sfException.class.php
@@ -259,7 +259,7 @@ class sfException extends Exception
     $templatePaths = array(
       sfConfig::get('sf_app_config_dir').'/error',
       sfConfig::get('sf_config_dir').'/error',
-      dirname(__FILE__).'/data',
+      __DIR__.'/data',
     );
 
     $template = sprintf('%s.%s.php', $debug ? 'exception' : 'error', $format);

--- a/lib/helper/DateHelper.php
+++ b/lib/helper/DateHelper.php
@@ -153,7 +153,7 @@ function distance_of_time_in_words($from_time, $to_time = null, $include_seconds
 
   if (sfConfig::get('sf_i18n'))
   {
-    require_once dirname(__FILE__).'/I18NHelper.php';
+    require_once __DIR__.'/I18NHelper.php';
 
     return __($string, $parameters);
   }

--- a/lib/i18n/Gettext/MO.php
+++ b/lib/i18n/Gettext/MO.php
@@ -21,7 +21,7 @@
  * @license     PHP License
  */
 
-require_once dirname(__FILE__).'/TGettext.class.php';
+require_once __DIR__.'/TGettext.class.php';
 
 /** 
  * File_Gettext_MO

--- a/lib/i18n/Gettext/PO.php
+++ b/lib/i18n/Gettext/PO.php
@@ -21,7 +21,7 @@
  * @license     PHP License
  */
  
-require_once dirname(__FILE__).'/TGettext.class.php';
+require_once __DIR__.'/TGettext.class.php';
 
 /** 
  * File_Gettext_PO

--- a/lib/i18n/Gettext/TGettext.class.php
+++ b/lib/i18n/Gettext/TGettext.class.php
@@ -84,7 +84,7 @@ class TGettext
     static function factory($format, $file = '')
     {
         $format = strToUpper($format);
-        $filename = dirname(__FILE__).'/'.$format.'.php';
+        $filename = __DIR__.'/'.$format.'.php';
         if (is_file($filename) == false)
         	throw new Exception ("Class file $file not found");
         	
@@ -112,7 +112,7 @@ class TGettext
             throw new Exception("File $pofile doesn't exist.");
         }
         
-        include_once dirname(__FILE__).'/PO.php';
+        include_once __DIR__.'/PO.php';
         
         $PO = new TGettext_PO($pofile);
         if (true !== ($e = $PO->load())) {
@@ -248,7 +248,7 @@ class TGettext
      */
     function toMO()
     {
-        include_once dirname(__FILE__).'/MO.php';
+        include_once __DIR__.'/MO.php';
         $MO = new TGettext_MO;
         $MO->fromArray($this->toArray());
         return $MO;
@@ -262,7 +262,7 @@ class TGettext
      */
     function toPO()
     {
-        include_once dirname(__FILE__).'/PO.php';
+        include_once __DIR__.'/PO.php';
         $PO = new TGettext_PO;
         $PO->fromArray($this->toArray());
         return $PO;

--- a/lib/i18n/sfCultureInfo.class.php
+++ b/lib/i18n/sfCultureInfo.class.php
@@ -225,7 +225,7 @@ class sfCultureInfo
    */
   protected static function dataDir()
   {
-    return dirname(__FILE__).'/data/';
+    return __DIR__.'/data/';
   }
 
   /**

--- a/lib/task/generator/sfGenerateAppTask.class.php
+++ b/lib/task/generator/sfGenerateAppTask.class.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/sfGeneratorBaseTask.class.php');
+require_once(__DIR__.'/sfGeneratorBaseTask.class.php');
 
 /**
  * Generates a new application.
@@ -101,7 +101,7 @@ EOF;
     }
     else
     {
-      $skeletonDir = dirname(__FILE__).'/skeleton/app';
+      $skeletonDir = __DIR__.'/skeleton/app';
     }
 
     // Create basic application structure

--- a/lib/task/generator/sfGenerateModuleTask.class.php
+++ b/lib/task/generator/sfGenerateModuleTask.class.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/sfGeneratorBaseTask.class.php');
+require_once(__DIR__.'/sfGeneratorBaseTask.class.php');
 
 /**
  * Generates a new module.
@@ -96,7 +96,7 @@ EOF;
     }
     else
     {
-      $skeletonDir = dirname(__FILE__).'/skeleton/module';
+      $skeletonDir = __DIR__.'/skeleton/module';
     }
 
     // create basic application structure

--- a/lib/task/generator/sfGenerateProjectTask.class.php
+++ b/lib/task/generator/sfGenerateProjectTask.class.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/sfGeneratorBaseTask.class.php');
+require_once(__DIR__.'/sfGeneratorBaseTask.class.php');
 
 /**
  * Generates a new project.
@@ -104,11 +104,11 @@ EOF;
     $this->options = $options;
 
     // create basic project structure
-    $this->installDir(dirname(__FILE__).'/skeleton/project');
+    $this->installDir(__DIR__.'/skeleton/project');
 
     // update ProjectConfiguration class (use a relative path when the symfony core is nested within the project)
     $symfonyCoreAutoload = 0 === strpos(sfConfig::get('sf_symfony_lib_dir'), sfConfig::get('sf_root_dir')) ?
-      sprintf('dirname(__FILE__).\'/..%s/autoload/sfCoreAutoload.class.php\'', str_replace(sfConfig::get('sf_root_dir'), '', sfConfig::get('sf_symfony_lib_dir'))) :
+      sprintf('__DIR__.\'/..%s/autoload/sfCoreAutoload.class.php\'', str_replace(sfConfig::get('sf_root_dir'), '', sfConfig::get('sf_symfony_lib_dir'))) :
       var_export(sfConfig::get('sf_symfony_lib_dir').'/autoload/sfCoreAutoload.class.php', true);
 
     $this->replaceTokens(array(sfConfig::get('sf_config_dir')), array('SYMFONY_CORE_AUTOLOAD' => str_replace('\\', '/', $symfonyCoreAutoload)));
@@ -125,7 +125,7 @@ EOF;
     // execute the choosen ORM installer script
     if (in_array($options['orm'], array('Doctrine')))
     {
-      include dirname(__FILE__).'/../../plugins/sf'.$options['orm'].'Plugin/config/installer.php';
+      include __DIR__.'/../../plugins/sf'.$options['orm'].'Plugin/config/installer.php';
     }
 
     // execute a custom installer

--- a/lib/task/generator/skeleton/app/web/index.php
+++ b/lib/task/generator/skeleton/app/web/index.php
@@ -1,7 +1,7 @@
 <?php
 
 ##IP_CHECK##
-require_once(dirname(__FILE__).'/../config/ProjectConfiguration.class.php');
+require_once(__DIR__.'/../config/ProjectConfiguration.class.php');
 
 $configuration = ProjectConfiguration::getApplicationConfiguration('##APP_NAME##', '##ENVIRONMENT##', ##IS_DEBUG##);
 sfContext::createInstance($configuration)->dispatch();

--- a/lib/task/generator/skeleton/module/test/actionsTest.php
+++ b/lib/task/generator/skeleton/module/test/actionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-include(dirname(__FILE__).'/../../bootstrap/functional.php');
+include(__DIR__.'/../../bootstrap/functional.php');
 
 $browser = new sfTestFunctional(new sfBrowser());
 

--- a/lib/task/generator/skeleton/project/symfony
+++ b/lib/task/generator/skeleton/project/symfony
@@ -9,6 +9,6 @@
  * file that was distributed with this source code.
  */
 
-chdir(dirname(__FILE__));
-require_once(dirname(__FILE__).'/config/ProjectConfiguration.class.php');
+chdir(__DIR__);
+require_once(__DIR__.'/config/ProjectConfiguration.class.php');
 include(sfCoreAutoload::getInstance()->getBaseDir().'/command/cli.php');

--- a/lib/task/generator/skeleton/project/test/bootstrap/functional.php
+++ b/lib/task/generator/skeleton/project/test/bootstrap/functional.php
@@ -18,7 +18,7 @@ if (!isset($app))
   $app = array_pop($dirPieces);
 }
 
-require_once dirname(__FILE__).'/../../config/ProjectConfiguration.class.php';
+require_once __DIR__.'/../../config/ProjectConfiguration.class.php';
 $configuration = ProjectConfiguration::getApplicationConfiguration($app, 'test', isset($debug) ? $debug : true);
 sfContext::createInstance($configuration);
 

--- a/lib/task/generator/skeleton/project/test/bootstrap/unit.php
+++ b/lib/task/generator/skeleton/project/test/bootstrap/unit.php
@@ -8,10 +8,10 @@
  * file that was distributed with this source code.
  */
 
-$_test_dir = realpath(dirname(__FILE__).'/..');
+$_test_dir = realpath(__DIR__.'/..');
 
 // configuration
-require_once dirname(__FILE__).'/../../config/ProjectConfiguration.class.php';
+require_once __DIR__.'/../../config/ProjectConfiguration.class.php';
 $configuration = ProjectConfiguration::hasActive() ? ProjectConfiguration::getActive() : new ProjectConfiguration(realpath($_test_dir.'/..'));
 
 // autoloader

--- a/lib/task/plugin/sfPluginAddChannelTask.class.php
+++ b/lib/task/plugin/sfPluginAddChannelTask.class.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/sfPluginBaseTask.class.php');
+require_once(__DIR__.'/sfPluginBaseTask.class.php');
 
 /**
  * Installs a plugin.

--- a/lib/task/plugin/sfPluginInstallTask.class.php
+++ b/lib/task/plugin/sfPluginInstallTask.class.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/sfPluginBaseTask.class.php');
+require_once(__DIR__.'/sfPluginBaseTask.class.php');
 
 /**
  * Installs a plugin.

--- a/lib/task/plugin/sfPluginListTask.class.php
+++ b/lib/task/plugin/sfPluginListTask.class.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/sfPluginBaseTask.class.php');
+require_once(__DIR__.'/sfPluginBaseTask.class.php');
 
 /**
  * Lists installed plugins.

--- a/lib/task/plugin/sfPluginPublishAssetsTask.class.php
+++ b/lib/task/plugin/sfPluginPublishAssetsTask.class.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/sfPluginBaseTask.class.php');
+require_once(__DIR__.'/sfPluginBaseTask.class.php');
 
 /**
  * Publishes Web Assets for Core and third party plugins

--- a/lib/task/plugin/sfPluginUninstallTask.class.php
+++ b/lib/task/plugin/sfPluginUninstallTask.class.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/sfPluginBaseTask.class.php');
+require_once(__DIR__.'/sfPluginBaseTask.class.php');
 
 /**
  * Uninstall a plugin.

--- a/lib/task/plugin/sfPluginUpgradeTask.class.php
+++ b/lib/task/plugin/sfPluginUpgradeTask.class.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/sfPluginBaseTask.class.php');
+require_once(__DIR__.'/sfPluginBaseTask.class.php');
 
 /**
  * Upgrades a plugin.

--- a/lib/task/project/sfProjectValidateTask.class.php
+++ b/lib/task/project/sfProjectValidateTask.class.php
@@ -82,7 +82,7 @@ EOF;
 
   protected function getUpgradeClasses()
   {
-    $baseDir = dirname(__FILE__).'/validation/';
+    $baseDir = __DIR__.'/validation/';
     $classes = array();
 
     foreach (glob($baseDir.'*.class.php') as $file)

--- a/lib/task/symfony/sfSymfonyTestTask.class.php
+++ b/lib/task/symfony/sfSymfonyTestTask.class.php
@@ -46,11 +46,11 @@ EOF;
    */
   protected function execute($arguments = array(), $options = array())
   {
-    require_once(dirname(__FILE__).'/../../vendor/lime/lime.php');
-    require_once(dirname(__FILE__).'/lime_symfony.php');
+    require_once(__DIR__.'/../../vendor/lime/lime.php');
+    require_once(__DIR__.'/lime_symfony.php');
 
     // cleanup
-    require_once(dirname(__FILE__).'/../../util/sfToolkit.class.php');
+    require_once(__DIR__.'/../../util/sfToolkit.class.php');
     if ($files = glob(sys_get_temp_dir().DIRECTORY_SEPARATOR.'/sf_autoload_unit_*'))
     {
       foreach ($files as $file)
@@ -62,12 +62,12 @@ EOF;
     // update sfCoreAutoload
     if ($options['update-autoloader'])
     {
-      require_once(dirname(__FILE__).'/../../autoload/sfCoreAutoload.class.php');
+      require_once(__DIR__.'/../../autoload/sfCoreAutoload.class.php');
       sfCoreAutoload::make();
     }
 
     $status = false;
-    $statusFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.sprintf('/.test_symfony_%s_status', md5(dirname(__FILE__)));
+    $statusFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.sprintf('/.test_symfony_%s_status', md5(__DIR__));
     if ($options['only-failed'])
     {
       if (file_exists($statusFile))
@@ -77,7 +77,7 @@ EOF;
     }
 
     $h = new lime_symfony(array('force_colors' => $options['color'], 'verbose' => $options['trace']));
-    $h->base_dir = realpath(dirname(__FILE__).'/../../../test');
+    $h->base_dir = realpath(__DIR__.'/../../../test');
 
     // remove generated files
     if ($options['rebuild-all'])

--- a/lib/task/test/sfLimeHarness.class.php
+++ b/lib/task/test/sfLimeHarness.class.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(__FILE__).'/../../vendor/lime/lime.php';
+require_once __DIR__.'/../../vendor/lime/lime.php';
 
 class sfLimeHarness extends lime_harness
 {

--- a/lib/task/test/sfTestAllTask.class.php
+++ b/lib/task/test/sfTestAllTask.class.php
@@ -76,7 +76,7 @@ EOF;
    */
   protected function execute($arguments = array(), $options = array())
   {
-    require_once dirname(__FILE__).'/sfLimeHarness.class.php';
+    require_once __DIR__.'/sfLimeHarness.class.php';
 
     $h = new sfLimeHarness(array(
       'force_colors' => isset($options['color']) && $options['color'],

--- a/lib/task/test/sfTestCoverageTask.class.php
+++ b/lib/task/test/sfTestCoverageTask.class.php
@@ -73,7 +73,7 @@ EOF;
 
   protected function getTestHarness($harnessOptions = array())
   {
-    require_once dirname(__FILE__).'/sfLimeHarness.class.php';
+    require_once __DIR__.'/sfLimeHarness.class.php';
 
     $harness = new sfLimeHarness($harnessOptions);
     $harness->addPlugins(array_map(array($this->configuration, 'getPluginConfiguration'), $this->configuration->getPlugins()));

--- a/lib/task/test/sfTestFunctionalTask.class.php
+++ b/lib/task/test/sfTestFunctionalTask.class.php
@@ -96,7 +96,7 @@ EOF;
     }
     else
     {
-      require_once dirname(__FILE__).'/sfLimeHarness.class.php';
+      require_once __DIR__.'/sfLimeHarness.class.php';
 
       $h = new sfLimeHarness(array(
         'force_colors' => isset($options['color']) && $options['color'],

--- a/lib/task/test/sfTestUnitTask.class.php
+++ b/lib/task/test/sfTestUnitTask.class.php
@@ -91,7 +91,7 @@ EOF;
     }
     else
     {
-      require_once dirname(__FILE__).'/sfLimeHarness.class.php';
+      require_once __DIR__.'/sfLimeHarness.class.php';
 
       $h = new sfLimeHarness(array(
         'force_colors' => isset($options['color']) && $options['color'],

--- a/lib/test/sfTestBrowser.class.php
+++ b/lib/test/sfTestBrowser.class.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(dirname(__FILE__).'/../vendor/lime/lime.php');
+require_once(__DIR__.'/../vendor/lime/lime.php');
 
 /*
  * This file is part of the symfony package.

--- a/lib/test/sfTestFunctionalBase.class.php
+++ b/lib/test/sfTestFunctionalBase.class.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(dirname(__FILE__).'/../vendor/lime/lime.php');
+require_once(__DIR__.'/../vendor/lime/lime.php');
 
 /*
  * This file is part of the symfony package.

--- a/lib/test/sfTesterResponse.class.php
+++ b/lib/test/sfTesterResponse.class.php
@@ -204,7 +204,7 @@ class sfTesterResponse extends sfTester
           $filesystem = new sfFilesystem();
 
           $finder = sfFinder::type('any')->discard('.sf');
-          $filesystem->mirror(dirname(__FILE__).'/w3', $cache, $finder);
+          $filesystem->mirror(__DIR__.'/w3', $cache, $finder);
 
           $finder = sfFinder::type('file');
           $filesystem->replaceTokens($finder->in($cache), '##', '##', array('LOCAL_W3' => $local));

--- a/test/bin/coverage.php
+++ b/test/bin/coverage.php
@@ -17,11 +17,11 @@ if (isset($argv[1]))
   $verbose = true;
 }
 
-require_once(dirname(__FILE__).'/../../lib/vendor/lime/lime.php');
-require_once(dirname(__FILE__).'/../../lib/util/sfFinder.class.php');
+require_once(__DIR__.'/../../lib/vendor/lime/lime.php');
+require_once(__DIR__.'/../../lib/util/sfFinder.class.php');
 
 $h = new lime_harness();
-$h->base_dir = realpath(dirname(__FILE__).'/..');
+$h->base_dir = realpath(__DIR__.'/..');
 
 // unit tests
 $h->register_glob(sprintf('%s/unit/*/%sTest.php', $h->base_dir, $name));
@@ -37,7 +37,7 @@ $h->register_glob(sprintf('%s/../lib/plugins/*/functional/%sTest.php', $h->base_
 $c = new lime_coverage($h);
 $c->extension = '.class.php';
 $c->verbose = $verbose;
-$c->base_dir = realpath(dirname(__FILE__).'/../../lib');
+$c->base_dir = realpath(__DIR__.'/../../lib');
 
 $finder = sfFinder::type('file')->name($name.'.class.php')->prune('vendor')->prune('test')->prune('data');
 

--- a/test/bin/loc.php
+++ b/test/bin/loc.php
@@ -1,6 +1,6 @@
 <?php
 
-$root_dir = realpath(dirname(__FILE__).'/../..');
+$root_dir = realpath(__DIR__.'/../..');
 require_once($root_dir.'/lib/vendor/lime/lime.php');
 require_once($root_dir.'/lib/util/sfFinder.class.php');
 

--- a/test/bootstrap/functional.php
+++ b/test/bootstrap/functional.php
@@ -16,7 +16,7 @@ ini_set('allow_url_fopen', 'on');
 
 if (!isset($root_dir))
 {
-  $root_dir = realpath(dirname(__FILE__).sprintf('/../%s/fixtures', isset($type) ? $type : 'functional'));
+  $root_dir = realpath(__DIR__.sprintf('/../%s/fixtures', isset($type) ? $type : 'functional'));
 }
 
 require_once $root_dir.'/config/ProjectConfiguration.class.php';

--- a/test/bootstrap/task.php
+++ b/test/bootstrap/task.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/unit.php');
+require_once(__DIR__.'/unit.php');
 
 require_once(sfConfig::get('sf_symfony_lib_dir').'/command/sfCommandApplication.class.php');
 require_once(sfConfig::get('sf_symfony_lib_dir').'/command/sfSymfonyCommandApplication.class.php');

--- a/test/bootstrap/unit.php
+++ b/test/bootstrap/unit.php
@@ -14,15 +14,15 @@ ini_set('session.auto_start', 'off');
 ini_set('arg_separator.output', '&amp;');
 ini_set('allow_url_fopen', 'on');
 
-$_test_dir = realpath(dirname(__FILE__).'/..');
+$_test_dir = realpath(__DIR__.'/..');
 require_once($_test_dir.'/../lib/vendor/lime/lime.php');
 require_once($_test_dir.'/../lib/config/sfConfig.class.php');
 sfConfig::set('sf_symfony_lib_dir', realpath($_test_dir.'/../lib'));
 
-require_once(dirname(__FILE__).'/../../lib/autoload/sfCoreAutoload.class.php');
+require_once(__DIR__.'/../../lib/autoload/sfCoreAutoload.class.php');
 sfCoreAutoload::register();
 
-require_once(dirname(__FILE__).'/../../lib/util/sfToolkit.class.php');
+require_once(__DIR__.'/../../lib/util/sfToolkit.class.php');
 sfConfig::set('sf_test_cache_dir', sys_get_temp_dir().'/sf_test_project');
 
 // remove all test cache

--- a/test/functional/authTest.php
+++ b/test/functional/authTest.php
@@ -9,7 +9,7 @@
  */
 
 $app = 'frontend';
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }

--- a/test/functional/autoloadTest.php
+++ b/test/functional/autoloadTest.php
@@ -9,7 +9,7 @@
  */
 
 $app = 'frontend';
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }

--- a/test/functional/cacheTest.php
+++ b/test/functional/cacheTest.php
@@ -9,7 +9,7 @@
  */
 
 $app = 'cache';
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }
@@ -322,7 +322,7 @@ class myTestBrowser extends sfTestBrowser
 $b = new myTestBrowser();
 
 // non HTML cache
-$image = file_get_contents(dirname(__FILE__).'/fixtures/apps/cache/modules/cache/data/ok48.png');
+$image = file_get_contents(__DIR__.'/fixtures/apps/cache/modules/cache/data/ok48.png');
 sfConfig::set('sf_web_debug', true);
 $b->
   get('/cache/imageWithLayoutCacheWithLayout')->

--- a/test/functional/escapingTest.php
+++ b/test/functional/escapingTest.php
@@ -9,7 +9,7 @@
  */
 
 $app = 'frontend';
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }

--- a/test/functional/filterTest.php
+++ b/test/functional/filterTest.php
@@ -9,7 +9,7 @@
  */
 
 $app = 'frontend';
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }

--- a/test/functional/fixtures/apps/cache/modules/cache/actions/actions.class.php
+++ b/test/functional/fixtures/apps/cache/modules/cache/actions/actions.class.php
@@ -92,7 +92,7 @@ class cacheActions extends sfActions
   protected function prepareImage()
   {
     $this->getResponse()->setContentType('image/png');
-    $this->image = file_get_contents(dirname(__FILE__).'/../data/ok48.png');
+    $this->image = file_get_contents(__DIR__.'/../data/ok48.png');
     $this->setTemplate('image');
   }
 

--- a/test/functional/fixtures/apps/frontend/lib/myAutoload.class.php
+++ b/test/functional/fixtures/apps/frontend/lib/myAutoload.class.php
@@ -6,7 +6,7 @@ class myAutoload
   {
     if ('myAutoloadedClass' == $class)
     {
-      require_once(dirname(__FILE__).'/myAutoloadedClass.class.php');
+      require_once(__DIR__.'/myAutoloadedClass.class.php');
 
       return true;
     }

--- a/test/functional/fixtures/config/ProjectConfiguration.class.php
+++ b/test/functional/fixtures/config/ProjectConfiguration.class.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(__FILE__).'/../../../../lib/autoload/sfCoreAutoload.class.php';
+require_once __DIR__.'/../../../../lib/autoload/sfCoreAutoload.class.php';
 sfCoreAutoload::register();
 
 class ProjectConfiguration extends sfProjectConfiguration

--- a/test/functional/fixtures/plugins/sfAutoloadPlugin/config/autoload.yml
+++ b/test/functional/fixtures/plugins/sfAutoloadPlugin/config/autoload.yml
@@ -1,11 +1,11 @@
 autoload:
   sfAutoloadPlugin_lib:
     name:       sfAutoloadPlugin lib
-    path:       <?php echo dirname(__FILE__)."/../lib\n" ?>
+    path:       <?php echo __DIR__."/../lib\n" ?>
     exclude:    [vendor]
     recursive:  true
 
   not_in_lib_class:
     name:       NotInLib class
     files:
-      NotInLib: <?php echo dirname(__FILE__)."/NotInLib.class.php\n" ?>
+      NotInLib: <?php echo __DIR__."/NotInLib.class.php\n" ?>

--- a/test/functional/fixtures/symfony
+++ b/test/functional/fixtures/symfony
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-chdir(dirname(__FILE__));
-require_once(dirname(__FILE__).'/config/ProjectConfiguration.class.php');
+chdir(__DIR__);
+require_once(__DIR__.'/config/ProjectConfiguration.class.php');
 $configuration = new ProjectConfiguration();
 include($configuration->getSymfonyLibDir().'/command/cli.php');

--- a/test/functional/formatTest.php
+++ b/test/functional/formatTest.php
@@ -9,7 +9,7 @@
  */
 
 $app = 'frontend';
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }

--- a/test/functional/genericTest.php
+++ b/test/functional/genericTest.php
@@ -9,7 +9,7 @@
  */
 
 $app = 'frontend';
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }

--- a/test/functional/httpcacheTest.php
+++ b/test/functional/httpcacheTest.php
@@ -9,7 +9,7 @@
  */
 
 $app = 'cache';
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }

--- a/test/functional/i18nFormTest.php
+++ b/test/functional/i18nFormTest.php
@@ -9,7 +9,7 @@
  */
 
 $app = 'i18n';
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }

--- a/test/functional/i18nTest.php
+++ b/test/functional/i18nTest.php
@@ -9,7 +9,7 @@
  */
 
 $app = 'i18n';
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }

--- a/test/functional/prodTest.php
+++ b/test/functional/prodTest.php
@@ -10,7 +10,7 @@
 
 $app = 'frontend';
 $debug = false;
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }

--- a/test/functional/sfTestBrowserTest.php
+++ b/test/functional/sfTestBrowserTest.php
@@ -9,7 +9,7 @@
  */
 
 $app = 'frontend';
-if (!include(dirname(__FILE__).'/../bootstrap/functional.php'))
+if (!include(__DIR__.'/../bootstrap/functional.php'))
 {
   return;
 }

--- a/test/other/fixtures/test/unit/testTest.php
+++ b/test/other/fixtures/test/unit/testTest.php
@@ -1,6 +1,6 @@
 <?php
 
-include(dirname(__FILE__).'/../bootstrap/unit.php');
+include(__DIR__.'/../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/other/tasksTest.php
+++ b/test/other/tasksTest.php
@@ -1,6 +1,6 @@
 <?php
 
-$_test_dir = realpath(dirname(__FILE__).'/..');
+$_test_dir = realpath(__DIR__.'/..');
 require_once($_test_dir.'/../lib/vendor/lime/lime.php');
 require_once($_test_dir.'/../lib/util/sfToolkit.class.php');
 
@@ -42,14 +42,14 @@ class sf_test_project
 
   protected function clearTmpDir()
   {
-    require_once(dirname(__FILE__).'/../../lib/util/sfToolkit.class.php');
+    require_once(__DIR__.'/../../lib/util/sfToolkit.class.php');
     sfToolkit::clearDirectory($this->tmp_dir);
   }
 
   public function execute_command($cmd, $awaited_return=0)
   {
     chdir($this->tmp_dir);
-    $symfony = file_exists('symfony') ? 'symfony' : dirname(__FILE__).'/../../data/bin/symfony';
+    $symfony = file_exists('symfony') ? 'symfony' : __DIR__.'/../../data/bin/symfony';
 
     ob_start();
     passthru(sprintf('%s "%s" %s 2>&1', $this->php_cli, $symfony, $cmd), $return);
@@ -61,7 +61,7 @@ class sf_test_project
 
   public function get_fixture_content($file)
   {
-    return str_replace("\r\n", "\n", file_get_contents(dirname(__FILE__).'/fixtures/'.$file));
+    return str_replace("\r\n", "\n", file_get_contents(__DIR__.'/fixtures/'.$file));
   }
 }
 
@@ -97,10 +97,10 @@ $content = $c->execute_command('generate:module wrongapp foo', 1);
 $content = $c->execute_command('generate:module frontend foo');
 $t->ok(is_dir($c->tmp_dir.DS.'apps'.DS.'frontend'.DS.'modules'.DS.'foo'), '"generate:module" creates a "foo" directory under "modules" directory');
 
-copy(dirname(__FILE__).'/fixtures/factories.yml', $c->tmp_dir.DS.'apps'.DS.'frontend'.DS.'config'.DS.'factories.yml');
+copy(__DIR__.'/fixtures/factories.yml', $c->tmp_dir.DS.'apps'.DS.'frontend'.DS.'config'.DS.'factories.yml');
 
 // test:*
-copy(dirname(__FILE__).'/fixtures/test/unit/testTest.php', $c->tmp_dir.DS.'test'.DS.'unit'.DS.'testTest.php');
+copy(__DIR__.'/fixtures/test/unit/testTest.php', $c->tmp_dir.DS.'test'.DS.'unit'.DS.'testTest.php');
 
 $content = $c->execute_command('test:unit test');
 $t->is($content, $c->get_fixture_content('/test/unit/result.txt'), '"test:unit" can launch a particular unit test');
@@ -113,7 +113,7 @@ $content = $c->execute_command('cache:clear');
 // Test task autoloading
 mkdir($c->tmp_dir.DS.'lib'.DS.'task');
 mkdir($pluginDir = $c->tmp_dir.DS.'plugins'.DS.'myFooPlugin'.DS.'lib'.DS.'task', 0777, true);
-copy(dirname(__FILE__).'/fixtures/task/myPluginTask.class.php', $pluginDir.DS.'myPluginTask.class.php');
+copy(__DIR__.'/fixtures/task/myPluginTask.class.php', $pluginDir.DS.'myPluginTask.class.php');
 file_put_contents(
   $projectConfigurationFile = $c->tmp_dir.DS.'config'.DS.'ProjectConfiguration.class.php',
   str_replace(

--- a/test/unit/action/sfComponentTest.php
+++ b/test/unit/action/sfComponentTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 require_once($_test_dir.'/unit/sfNoRouting.class.php');
 

--- a/test/unit/addon/sfPagerTest.php
+++ b/test/unit/addon/sfPagerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(2);
 class myPager extends sfPager

--- a/test/unit/autoload/sfCoreAutoloadTest.php
+++ b/test/unit/autoload/sfCoreAutoloadTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once dirname(__FILE__).'/../../bootstrap/unit.php';
+require_once __DIR__.'/../../bootstrap/unit.php';
 
 $t = new lime_test(1);
 

--- a/test/unit/autoload/sfSimpleAutoloadTest.php
+++ b/test/unit/autoload/sfSimpleAutoloadTest.php
@@ -8,12 +8,12 @@
  * file that was distributed with this source code.
  */
 
-require_once dirname(__FILE__).'/../../bootstrap/unit.php';
+require_once __DIR__.'/../../bootstrap/unit.php';
 
 $t = new lime_test(1);
 
 $autoload = sfSimpleAutoload::getInstance();
-$autoload->addFile(dirname(__FILE__).'/../sfEventDispatcherTest.class.php');
+$autoload->addFile(__DIR__.'/../sfEventDispatcherTest.class.php');
 $autoload->register();
 
 $t->is(class_exists('myeventdispatchertest'), true, '"sfSimpleAutoload" is case insensitive');

--- a/test/unit/cache/sfAPCCacheTest.php
+++ b/test/unit/cache/sfAPCCacheTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $plan = 64;
 $t = new lime_test($plan);
@@ -29,7 +29,7 @@ if (!ini_get('apc.enable_cli'))
   return;
 }
 
-require_once(dirname(__FILE__).'/sfCacheDriverTests.class.php');
+require_once(__DIR__.'/sfCacheDriverTests.class.php');
 
 // setup
 sfConfig::set('sf_logging_enabled', false);

--- a/test/unit/cache/sfCacheTest.php
+++ b/test/unit/cache/sfCacheTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class myCache extends sfCache
 {

--- a/test/unit/cache/sfEAcceleratorCacheTest.php
+++ b/test/unit/cache/sfEAcceleratorCacheTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $plan = 64;
 $t = new lime_test($plan);
@@ -23,7 +23,7 @@ catch (sfInitializationException $e)
   return;
 }
 
-require_once(dirname(__FILE__).'/sfCacheDriverTests.class.php');
+require_once(__DIR__.'/sfCacheDriverTests.class.php');
 
 // setup
 sfConfig::set('sf_logging_enabled', false);

--- a/test/unit/cache/sfFileCacheTest.php
+++ b/test/unit/cache/sfFileCacheTest.php
@@ -8,8 +8,8 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
-require_once(dirname(__FILE__).'/sfCacheDriverTests.class.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
+require_once(__DIR__.'/sfCacheDriverTests.class.php');
 
 $t = new lime_test(65);
 

--- a/test/unit/cache/sfFunctionCacheTest.php
+++ b/test/unit/cache/sfFunctionCacheTest.php
@@ -8,8 +8,8 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
-require_once(dirname(__FILE__).'/sfCacheDriverTests.class.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
+require_once(__DIR__.'/sfCacheDriverTests.class.php');
 
 $t = new lime_test(15);
 

--- a/test/unit/cache/sfMemcacheCacheTest.php
+++ b/test/unit/cache/sfMemcacheCacheTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $plan = 73;
 $t = new lime_test($plan);
@@ -19,7 +19,7 @@ if (!class_exists('Memcache'))
   return;
 }
 
-require_once(dirname(__FILE__).'/sfCacheDriverTests.class.php');
+require_once(__DIR__.'/sfCacheDriverTests.class.php');
 
 // setup
 sfConfig::set('sf_logging_enabled', false);

--- a/test/unit/cache/sfNoCacheTest.php
+++ b/test/unit/cache/sfNoCacheTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(8);
 

--- a/test/unit/cache/sfSQLiteCacheTest.php
+++ b/test/unit/cache/sfSQLiteCacheTest.php
@@ -8,8 +8,8 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
-require_once(dirname(__FILE__).'/sfCacheDriverTests.class.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
+require_once(__DIR__.'/sfCacheDriverTests.class.php');
 
 $plan = 129;
 $t = new lime_test($plan);

--- a/test/unit/cache/sfXCacheCacheTest.php
+++ b/test/unit/cache/sfXCacheCacheTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $plan = 64;
 $t = new lime_test($plan);
@@ -23,7 +23,7 @@ catch (sfInitializationException $e)
   return;
 }
 
-require_once(dirname(__FILE__).'/sfCacheDriverTests.class.php');
+require_once(__DIR__.'/sfCacheDriverTests.class.php');
 
 // setup
 sfConfig::set('sf_logging_enabled', false);

--- a/test/unit/command/sfCommandArgumentSetTest.php
+++ b/test/unit/command/sfCommandArgumentSetTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(21);
 

--- a/test/unit/command/sfCommandArgumentTest.php
+++ b/test/unit/command/sfCommandArgumentTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(16);
 

--- a/test/unit/command/sfCommandManagerTest.php
+++ b/test/unit/command/sfCommandManagerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(41);
 

--- a/test/unit/command/sfCommandOptionSetTest.php
+++ b/test/unit/command/sfCommandOptionSetTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(20);
 

--- a/test/unit/command/sfCommandOptionTest.php
+++ b/test/unit/command/sfCommandOptionTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(34);
 

--- a/test/unit/config/sfCompileConfigHandlerTest.php
+++ b/test/unit/config/sfCompileConfigHandlerTest.php
@@ -8,14 +8,14 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(2);
 
 $handler = new sfCompileConfigHandler();
 $handler->initialize();
 
-$dir = dirname(__FILE__).DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfCompileConfigHandler'.DIRECTORY_SEPARATOR;
+$dir = __DIR__.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfCompileConfigHandler'.DIRECTORY_SEPARATOR;
 
 $t->diag('execute');
 

--- a/test/unit/config/sfConfigHandlerTest.php
+++ b/test/unit/config/sfConfigHandlerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(8);
 

--- a/test/unit/config/sfConfigTest.php
+++ b/test/unit/config/sfConfigTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(9);
 

--- a/test/unit/config/sfDefineEnvironmentConfigHandlerTest.php
+++ b/test/unit/config/sfDefineEnvironmentConfigHandlerTest.php
@@ -8,9 +8,9 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
-sfConfig::set('sf_symfony_lib_dir', realpath(dirname(__FILE__).'/../../../lib'));
+sfConfig::set('sf_symfony_lib_dir', realpath(__DIR__.'/../../../lib'));
 
 $t = new lime_test(1);
 
@@ -18,7 +18,7 @@ $t = new lime_test(1);
 $handler = new sfDefineEnvironmentConfigHandler();
 $handler->initialize(array('prefix' => 'sf_'));
 
-$dir = dirname(__FILE__).DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfDefineEnvironmentConfigHandler'.DIRECTORY_SEPARATOR;
+$dir = __DIR__.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfDefineEnvironmentConfigHandler'.DIRECTORY_SEPARATOR;
 
 $files = array(
   $dir.'prefix_default.yml',

--- a/test/unit/config/sfFilterConfigHandlerTest.php
+++ b/test/unit/config/sfFilterConfigHandlerTest.php
@@ -8,14 +8,14 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(8);
 
 $handler = new sfFilterConfigHandler();
 $handler->initialize();
 
-$dir = dirname(__FILE__).DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfFilterConfigHandler'.DIRECTORY_SEPARATOR;
+$dir = __DIR__.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfFilterConfigHandler'.DIRECTORY_SEPARATOR;
 
 // parse errors
 $t->diag('parse errors');

--- a/test/unit/config/sfGeneratorConfigHandlerTest.php
+++ b/test/unit/config/sfGeneratorConfigHandlerTest.php
@@ -8,16 +8,16 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
-sfConfig::set('sf_symfony_lib_dir', realpath(dirname(__FILE__).'/../../../lib'));
+sfConfig::set('sf_symfony_lib_dir', realpath(__DIR__.'/../../../lib'));
 
 $t = new lime_test(5);
 
 $handler = new sfGeneratorConfigHandler();
 $handler->initialize();
 
-$dir = dirname(__FILE__).DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfGeneratorConfigHandler'.DIRECTORY_SEPARATOR;
+$dir = __DIR__.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfGeneratorConfigHandler'.DIRECTORY_SEPARATOR;
 
 $t->diag('parse errors');
 $files = array(

--- a/test/unit/config/sfPluginConfigurationTest.php
+++ b/test/unit/config/sfPluginConfigurationTest.php
@@ -8,9 +8,9 @@
  * file that was distributed with this source code.
  */
 
-require_once dirname(__FILE__).'/../../bootstrap/unit.php';
+require_once __DIR__.'/../../bootstrap/unit.php';
 
-$rootDir = realpath(dirname(__FILE__).'/../../functional/fixtures');
+$rootDir = realpath(__DIR__.'/../../functional/fixtures');
 $pluginRoot = realpath($rootDir.'/plugins/sfAutoloadPlugin');
 
 require_once $pluginRoot.'/config/sfAutoloadPluginConfiguration.class.php';

--- a/test/unit/config/sfProjectConfigurationTest.php
+++ b/test/unit/config/sfProjectConfigurationTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(6);
 
@@ -21,7 +21,7 @@ class ProjectConfiguration extends sfProjectConfiguration
   }
 }
 
-$configuration = new ProjectConfiguration(dirname(__FILE__).'/../../functional/fixtures');
+$configuration = new ProjectConfiguration(__DIR__.'/../../functional/fixtures');
 
 // ->setPlugins() ->disablePlugins() ->enablePlugins() ->enableAllPluginsExcept()
 $t->diag('->setPlugins() ->disablePlugins() ->enablePlugins() ->enableAllPluginsExcept()');
@@ -47,7 +47,7 @@ class ProjectConfiguration2 extends sfProjectConfiguration
   }
 }
 
-$configuration = new ProjectConfiguration2(dirname(__FILE__).'/../../functional/fixtures');
+$configuration = new ProjectConfiguration2(__DIR__.'/../../functional/fixtures');
 $t->is_deeply($configuration->getPlugins(), array('sfAutoloadPlugin', 'sfConfigPlugin'), '->enablePlugins() can enable plugins passed as arguments instead of array');
 
 // ->__construct()
@@ -63,7 +63,7 @@ class ProjectConfiguration3 extends sfProjectConfiguration
 
 try
 {
-  $configuration = new ProjectConfiguration3(dirname(__FILE__).'/../../functional/fixtures');
+  $configuration = new ProjectConfiguration3(__DIR__.'/../../functional/fixtures');
   $t->fail('->__construct() throws an exception if a non-existant plugin is enabled');
 }
 catch (Exception $e)

--- a/test/unit/config/sfSimpleYamlConfigHandlerTest.php
+++ b/test/unit/config/sfSimpleYamlConfigHandlerTest.php
@@ -8,14 +8,14 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(2);
 
 $config = new sfSimpleYamlConfigHandler();
 $config->initialize();
 
-$dir = dirname(__FILE__).DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfSimpleYamlConfigHandler'.DIRECTORY_SEPARATOR;
+$dir = __DIR__.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'sfSimpleYamlConfigHandler'.DIRECTORY_SEPARATOR;
 
 $array = get_retval($config, array($dir.'config.yml'));
 $t->is($array['article']['title'], 'foo', '->execute() returns configuration file as an array');

--- a/test/unit/config/sfViewConfigHandlerTest.php
+++ b/test/unit/config/sfViewConfigHandlerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(22);
 

--- a/test/unit/config/sfYamlConfigHandlerTest.php
+++ b/test/unit/config/sfYamlConfigHandlerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(7);
 

--- a/test/unit/controller/sfControllerTest.php
+++ b/test/unit/controller/sfControllerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 
 $t = new lime_test(2);

--- a/test/unit/controller/sfWebControllerTest.php
+++ b/test/unit/controller/sfWebControllerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 require_once($_test_dir.'/unit/sfNoRouting.class.php');
 

--- a/test/unit/database/sfDatabaseTest.php
+++ b/test/unit/database/sfDatabaseTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 
 $t = new lime_test(10);

--- a/test/unit/debug/sfDebugTest.php
+++ b/test/unit/debug/sfDebugTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/debug/sfTimerTest.php
+++ b/test/unit/debug/sfTimerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(6);
 

--- a/test/unit/debug/sfWebDebugTest.php
+++ b/test/unit/debug/sfWebDebugTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once dirname(__FILE__).'/../../bootstrap/unit.php';
+require_once __DIR__.'/../../bootstrap/unit.php';
 
 $t = new lime_test(10);
 

--- a/test/unit/escaper/sfOutputEscaperArrayDecoratorTest.php
+++ b/test/unit/escaper/sfOutputEscaperArrayDecoratorTest.php
@@ -8,15 +8,15 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../lib/vendor/lime/lime.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaper.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperGetterDecorator.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperArrayDecorator.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperObjectDecorator.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperIteratorDecorator.class.php');
+require_once(__DIR__.'/../../../lib/vendor/lime/lime.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaper.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperGetterDecorator.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperArrayDecorator.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperObjectDecorator.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperIteratorDecorator.class.php');
 
-require_once(dirname(__FILE__).'/../../../lib/helper/EscapingHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/config/sfConfig.class.php');
+require_once(__DIR__.'/../../../lib/helper/EscapingHelper.php');
+require_once(__DIR__.'/../../../lib/config/sfConfig.class.php');
 
 class sfException extends Exception
 {

--- a/test/unit/escaper/sfOutputEscaperObjectDecoratorTest.php
+++ b/test/unit/escaper/sfOutputEscaperObjectDecoratorTest.php
@@ -8,15 +8,15 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../lib/vendor/lime/lime.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaper.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperGetterDecorator.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperArrayDecorator.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperObjectDecorator.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperIteratorDecorator.class.php');
+require_once(__DIR__.'/../../../lib/vendor/lime/lime.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaper.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperGetterDecorator.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperArrayDecorator.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperObjectDecorator.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperIteratorDecorator.class.php');
 
-require_once(dirname(__FILE__).'/../../../lib/helper/EscapingHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/config/sfConfig.class.php');
+require_once(__DIR__.'/../../../lib/helper/EscapingHelper.php');
+require_once(__DIR__.'/../../../lib/config/sfConfig.class.php');
 
 class sfException extends Exception
 {

--- a/test/unit/escaper/sfOutputEscaperSafeTest.php
+++ b/test/unit/escaper/sfOutputEscaperSafeTest.php
@@ -8,9 +8,9 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../lib/vendor/lime/lime.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/EscapingHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperSafe.class.php');
+require_once(__DIR__.'/../../../lib/vendor/lime/lime.php');
+require_once(__DIR__.'/../../../lib/helper/EscapingHelper.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperSafe.class.php');
 
 $t = new lime_test(13);
 

--- a/test/unit/escaper/sfOutputEscaperTest.php
+++ b/test/unit/escaper/sfOutputEscaperTest.php
@@ -8,16 +8,16 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../lib/vendor/lime/lime.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaper.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperGetterDecorator.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperArrayDecorator.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperObjectDecorator.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperIteratorDecorator.class.php');
-require_once(dirname(__FILE__).'/../../../lib/escaper/sfOutputEscaperSafe.class.php');
+require_once(__DIR__.'/../../../lib/vendor/lime/lime.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaper.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperGetterDecorator.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperArrayDecorator.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperObjectDecorator.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperIteratorDecorator.class.php');
+require_once(__DIR__.'/../../../lib/escaper/sfOutputEscaperSafe.class.php');
 
-require_once(dirname(__FILE__).'/../../../lib/helper/EscapingHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/config/sfConfig.class.php');
+require_once(__DIR__.'/../../../lib/helper/EscapingHelper.php');
+require_once(__DIR__.'/../../../lib/config/sfConfig.class.php');
 
 sfConfig::set('sf_charset', 'UTF-8');
 

--- a/test/unit/event/sfEventDispatcherTest.php
+++ b/test/unit/event/sfEventDispatcherTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(19);
 

--- a/test/unit/event/sfEventTest.php
+++ b/test/unit/event/sfEventTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(11);
 

--- a/test/unit/exception/sfExceptionsTest.php
+++ b/test/unit/exception/sfExceptionsTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(24);
 

--- a/test/unit/filter/sfFilterTest.php
+++ b/test/unit/filter/sfFilterTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 
 $t = new lime_test(17);

--- a/test/unit/form/addon/sfFormSymfonyTest.php
+++ b/test/unit/form/addon/sfFormSymfonyTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(8);
 

--- a/test/unit/form/sfFormFieldSchemaTest.php
+++ b/test/unit/form/sfFormFieldSchemaTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(11);
 

--- a/test/unit/form/sfFormFieldTest.php
+++ b/test/unit/form/sfFormFieldTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(31);
 

--- a/test/unit/form/sfFormTest.php
+++ b/test/unit/form/sfFormTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(155);
 

--- a/test/unit/generator/sfGeneratorTest.php
+++ b/test/unit/generator/sfGeneratorTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(0);
 

--- a/test/unit/generator/sfModelGeneratorConfigurationFieldTest.php
+++ b/test/unit/generator/sfModelGeneratorConfigurationFieldTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once dirname(__FILE__).'/../../bootstrap/unit.php';
+require_once __DIR__.'/../../bootstrap/unit.php';
 
 $t = new lime_test(12);
 

--- a/test/unit/helper/AssetHelperTest.php
+++ b/test/unit/helper/AssetHelperTest.php
@@ -8,12 +8,12 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 
-require_once(dirname(__FILE__).'/../../../lib/helper/TagHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/UrlHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/AssetHelper.php');
+require_once(__DIR__.'/../../../lib/helper/TagHelper.php');
+require_once(__DIR__.'/../../../lib/helper/UrlHelper.php');
+require_once(__DIR__.'/../../../lib/helper/AssetHelper.php');
 
 $t = new lime_test(68);
 

--- a/test/unit/helper/DateHelperTest.php
+++ b/test/unit/helper/DateHelperTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 
 $t = new lime_test(592);
@@ -27,9 +27,9 @@ sfConfig::set('sf_charset', 'utf-8');
 
 $context = sfContext::getInstance(array('user' => 'sfUser'));
 
-require_once(dirname(__FILE__).'/../../../lib/helper/UrlHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/TagHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/DateHelper.php');
+require_once(__DIR__.'/../../../lib/helper/UrlHelper.php');
+require_once(__DIR__.'/../../../lib/helper/TagHelper.php');
+require_once(__DIR__.'/../../../lib/helper/DateHelper.php');
 
 // get a fixed timestamp to test with
 $now = time();

--- a/test/unit/helper/EscapingHelperTest.php
+++ b/test/unit/helper/EscapingHelperTest.php
@@ -8,9 +8,9 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
-require_once(dirname(__FILE__).'/../../../lib/helper/EscapingHelper.php');
+require_once(__DIR__.'/../../../lib/helper/EscapingHelper.php');
 
 $t = new lime_test(11);
 

--- a/test/unit/helper/JavascriptBaseHelperTest.php
+++ b/test/unit/helper/JavascriptBaseHelperTest.php
@@ -8,9 +8,9 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/TagHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/JavascriptBaseHelper.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../lib/helper/TagHelper.php');
+require_once(__DIR__.'/../../../lib/helper/JavascriptBaseHelper.php');
 
 $t = new lime_test(9, new lime_output_color());
 

--- a/test/unit/helper/NumberHelperTest.php
+++ b/test/unit/helper/NumberHelperTest.php
@@ -8,8 +8,8 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/NumberHelper.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../lib/helper/NumberHelper.php');
 
 $t = new lime_test(12);
 

--- a/test/unit/helper/PartialHelperTest.php
+++ b/test/unit/helper/PartialHelperTest.php
@@ -8,9 +8,9 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/PartialHelper.php');
+require_once(__DIR__.'/../../../lib/helper/PartialHelper.php');
 
 // Fixme: make this test more beautiful and extend it
 

--- a/test/unit/helper/TagHelperTest.php
+++ b/test/unit/helper/TagHelperTest.php
@@ -8,14 +8,14 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 
 $t = new lime_test(21);
 
 $context = sfContext::getInstance();
 
-require_once(dirname(__FILE__).'/../../../lib/helper/TagHelper.php');
+require_once(__DIR__.'/../../../lib/helper/TagHelper.php');
 
 // tag()
 $t->diag('tag()');

--- a/test/unit/helper/TextHelperTest.php
+++ b/test/unit/helper/TextHelperTest.php
@@ -8,10 +8,10 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../test/bootstrap/unit.php');
+require_once(__DIR__.'/../../../test/bootstrap/unit.php');
 
-require_once(dirname(__FILE__).'/../../../lib/helper/TagHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/TextHelper.php');
+require_once(__DIR__.'/../../../lib/helper/TagHelper.php');
+require_once(__DIR__.'/../../../lib/helper/TextHelper.php');
 
 $t = new lime_test(60);
 

--- a/test/unit/helper/UrlHelperTest.php
+++ b/test/unit/helper/UrlHelperTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 
 class myController
@@ -52,9 +52,9 @@ $t = new lime_test(44);
 
 $context = sfContext::getInstance(array('controller' => 'myController', 'request' => 'myRequest'));
 
-require_once(dirname(__FILE__).'/../../../lib/helper/AssetHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/UrlHelper.php');
-require_once(dirname(__FILE__).'/../../../lib/helper/TagHelper.php');
+require_once(__DIR__.'/../../../lib/helper/AssetHelper.php');
+require_once(__DIR__.'/../../../lib/helper/UrlHelper.php');
+require_once(__DIR__.'/../../../lib/helper/TagHelper.php');
 
 // url_for()
 $t->diag('url_for()');

--- a/test/unit/i18n/dataTest.php
+++ b/test/unit/i18n/dataTest.php
@@ -8,12 +8,12 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(92);
 
 $t->diag('i18n data');
-$en = unserialize(file_get_contents(dirname(__FILE__).'/../../../lib/i18n/data/en.dat'));
+$en = unserialize(file_get_contents(__DIR__.'/../../../lib/i18n/data/en.dat'));
 
 // check main keys
 foreach (array('Countries', 'Currencies', 'Languages', 'LocaleScript', 'NumberPatterns', 'Scripts', 'Types', 'Variants', 'Version', 'calendar', 'zoneStrings') as $entry)

--- a/test/unit/i18n/extract/sfI18nExtractTest.php
+++ b/test/unit/i18n/extract/sfI18nExtractTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(3);
 
@@ -20,7 +20,7 @@ class TestConfiguration extends sfApplicationConfiguration
 {
   public function getI18NGlobalDirs()
   {
-    return array(dirname(__FILE__).'/../fixtures');
+    return array(__DIR__.'/../fixtures');
   }
 }
 

--- a/test/unit/i18n/extract/sfI18nPhpExtractorTest.php
+++ b/test/unit/i18n/extract/sfI18nPhpExtractorTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(7);
 

--- a/test/unit/i18n/extract/sfI18nYamlGeneratorExtractorTest.php
+++ b/test/unit/i18n/extract/sfI18nYamlGeneratorExtractorTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(3);
 

--- a/test/unit/i18n/extract/sfI18nYamlValidateExtractorTest.php
+++ b/test/unit/i18n/extract/sfI18nYamlValidateExtractorTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(2);
 

--- a/test/unit/i18n/sfChoiceFormatTest.php
+++ b/test/unit/i18n/sfChoiceFormatTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(90);
 

--- a/test/unit/i18n/sfCultureInfoTest.php
+++ b/test/unit/i18n/sfCultureInfoTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(67);
 

--- a/test/unit/i18n/sfI18NTest.php
+++ b/test/unit/i18n/sfI18NTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(34);
 
@@ -20,7 +20,7 @@ class TestConfiguration extends sfApplicationConfiguration
 {
   public function getI18NGlobalDirs()
   {
-    return array(dirname(__FILE__).'/fixtures');
+    return array(__DIR__.'/fixtures');
   }
 }
 

--- a/test/unit/i18n/sfMessageSourceTest.php
+++ b/test/unit/i18n/sfMessageSourceTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(3);
 

--- a/test/unit/i18n/sfMessageSource_AggregateTest.php
+++ b/test/unit/i18n/sfMessageSource_AggregateTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(9);
 
@@ -22,8 +22,8 @@ unlink($temp2);
 mkdir($temp2);
 
 // copy fixtures to tmp directory
-copy(dirname(__FILE__).'/fixtures/messages.fr.xml', $temp1.'/messages.fr.xml');
-copy(dirname(__FILE__).'/fixtures/messages_bis.fr.xml', $temp2.'/messages.fr.xml');
+copy(__DIR__.'/fixtures/messages.fr.xml', $temp1.'/messages.fr.xml');
+copy(__DIR__.'/fixtures/messages_bis.fr.xml', $temp2.'/messages.fr.xml');
 
 $source = get_source($temp1, $temp2);
 $source->setCulture('fr_FR');

--- a/test/unit/i18n/sfMessageSource_FileTest.php
+++ b/test/unit/i18n/sfMessageSource_FileTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(7);
 
@@ -26,7 +26,7 @@ class sfMessageSource_Simple extends sfMessageSource_File
   }
 }
 
-$source = sfMessageSource::factory('Simple', dirname(__FILE__).'/fixtures');
+$source = sfMessageSource::factory('Simple', __DIR__.'/fixtures');
 $source->setCulture('fr_FR');
 
 // ->getCatalogueByDir()
@@ -39,7 +39,7 @@ $t->is($source->getCatalogueList('messages'), array('fr_FR/messages.xml', 'fr/me
 
 // ->getSource()
 $t->diag('->getSource()');
-$t->is($source->getSource('fr_FR/messages.xml'), dirname(__FILE__).'/fixtures/fr_FR/messages.xml', '->getSource() returns the full path name to a specific variant');
+$t->is($source->getSource('fr_FR/messages.xml'), __DIR__.'/fixtures/fr_FR/messages.xml', '->getSource() returns the full path name to a specific variant');
 
 // ->isValidSource()
 $t->diag('->isValidSource()');

--- a/test/unit/i18n/sfMessageSource_SQLiteTest.php
+++ b/test/unit/i18n/sfMessageSource_SQLiteTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $plan = 10;
 $t = new lime_test($plan);
@@ -20,7 +20,7 @@ if (!extension_loaded('SQLite') && !extension_loaded('pdo_SQLite'))
 }
 
 // setup
-$temp = dirname(__FILE__).'/'.rand(11111, 99999);
+$temp = __DIR__.'/'.rand(11111, 99999);
 sf_test_shutdown();
 
 register_shutdown_function('sf_test_shutdown');

--- a/test/unit/i18n/sfMessageSource_XLIFFTest.php
+++ b/test/unit/i18n/sfMessageSource_XLIFFTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(11);
 
@@ -18,7 +18,7 @@ unlink($temp);
 mkdir($temp);
 
 // copy fixtures to tmp directory
-copy(dirname(__FILE__).'/fixtures/messages.fr.xml', $temp.'/messages.fr.xml');
+copy(__DIR__.'/fixtures/messages.fr.xml', $temp.'/messages.fr.xml');
 
 $source = sfMessageSource::factory('XLIFF', $temp);
 $source->setCulture('fr_FR');

--- a/test/unit/i18n/sfNumberFormatInfoTest.php
+++ b/test/unit/i18n/sfNumberFormatInfoTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(75);
 

--- a/test/unit/log/sfAggregateLoggerTest.php
+++ b/test/unit/log/sfAggregateLoggerTest.php
@@ -8,13 +8,13 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(6);
 
 $dispatcher = new sfEventDispatcher();
 
-require_once(dirname(__FILE__).'/../../../lib/util/sfToolkit.class.php');
+require_once(__DIR__.'/../../../lib/util/sfToolkit.class.php');
 $file = sys_get_temp_dir().DIRECTORY_SEPARATOR.'sf_log_file.txt';
 if (file_exists($file))
 {

--- a/test/unit/log/sfConsoleLoggerTest.php
+++ b/test/unit/log/sfConsoleLoggerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/log/sfFileLoggerTest.php
+++ b/test/unit/log/sfFileLoggerTest.php
@@ -8,11 +8,11 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(7);
 
-require_once(dirname(__FILE__).'/../../../lib/util/sfToolkit.class.php');
+require_once(__DIR__.'/../../../lib/util/sfToolkit.class.php');
 $file = sys_get_temp_dir().DIRECTORY_SEPARATOR.'sf_log_file.txt';
 if (file_exists($file))
 {

--- a/test/unit/log/sfLoggerTest.php
+++ b/test/unit/log/sfLoggerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(136);
 

--- a/test/unit/log/sfLoggerWrapperTest.php
+++ b/test/unit/log/sfLoggerWrapperTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(2);
 

--- a/test/unit/log/sfStreamLoggerTest.php
+++ b/test/unit/log/sfStreamLoggerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/log/sfVarLoggerTest.php
+++ b/test/unit/log/sfVarLoggerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(9);
 

--- a/test/unit/log/sfWebDebugLoggerTest.php
+++ b/test/unit/log/sfWebDebugLoggerTest.php
@@ -8,8 +8,8 @@
  * file that was distributed with this source code.
  */
 
-require_once dirname(__FILE__).'/../../bootstrap/unit.php';
-require_once dirname(__FILE__).'/../sfContextMock.class.php';
+require_once __DIR__.'/../../bootstrap/unit.php';
+require_once __DIR__.'/../sfContextMock.class.php';
 
 $t = new lime_test(1);
 

--- a/test/unit/mailer/sfMailerTest.php
+++ b/test/unit/mailer/sfMailerTest.php
@@ -7,12 +7,12 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-require_once dirname(__FILE__) . '/../../bootstrap/unit.php';
+require_once __DIR__ . '/../../bootstrap/unit.php';
 require_once sfConfig::get('sf_symfony_lib_dir').'/vendor/swiftmailer/lib/classes/Swift.php';
 Swift::registerAutoload(sfConfig::get('sf_symfony_lib_dir').'/vendor/swiftmailer/lib/swift_init.php');
-require_once dirname(__FILE__).'/fixtures/TestMailerTransport.class.php';
-require_once dirname(__FILE__).'/fixtures/TestSpool.class.php';
-require_once dirname(__FILE__).'/fixtures/TestMailMessage.class.php';
+require_once __DIR__.'/fixtures/TestMailerTransport.class.php';
+require_once __DIR__.'/fixtures/TestSpool.class.php';
+require_once __DIR__.'/fixtures/TestMailMessage.class.php';
 
 $t = new lime_test(34);
 

--- a/test/unit/plugin/sfPearEnvironmentTest.php
+++ b/test/unit/plugin/sfPearEnvironmentTest.php
@@ -10,7 +10,7 @@
 
 error_reporting(error_reporting() & ~E_STRICT);
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(3);
 
@@ -21,9 +21,9 @@ if (!class_exists('PEAR'))
   return;
 }
 
-require_once dirname(__FILE__).'/sfPearDownloaderTest.class.php';
-require_once dirname(__FILE__).'/sfPearRestTest.class.php';
-require_once dirname(__FILE__).'/sfPluginTestHelper.class.php';
+require_once __DIR__.'/sfPearDownloaderTest.class.php';
+require_once __DIR__.'/sfPearRestTest.class.php';
+require_once __DIR__.'/sfPluginTestHelper.class.php';
 
 // setup
 $temp = tempnam('/tmp/sf_plugin_test', 'tmp');

--- a/test/unit/plugin/sfPearRestPluginTest.php
+++ b/test/unit/plugin/sfPearRestPluginTest.php
@@ -10,7 +10,7 @@
 
 error_reporting(error_reporting() & ~E_STRICT);
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(5);
 
@@ -21,9 +21,9 @@ if (!class_exists('PEAR'))
   return;
 }
 
-require_once dirname(__FILE__).'/sfPearDownloaderTest.class.php';
-require_once dirname(__FILE__).'/sfPearRestTest.class.php';
-require_once dirname(__FILE__).'/sfPluginTestHelper.class.php';
+require_once __DIR__.'/sfPearDownloaderTest.class.php';
+require_once __DIR__.'/sfPearRestTest.class.php';
+require_once __DIR__.'/sfPluginTestHelper.class.php';
 
 // setup
 $temp = tempnam('/tmp/sf_plugin_test', 'tmp');

--- a/test/unit/plugin/sfPluginManagerTest.php
+++ b/test/unit/plugin/sfPluginManagerTest.php
@@ -10,7 +10,7 @@
 
 error_reporting(error_reporting() & ~E_STRICT);
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(40);
 
@@ -21,9 +21,9 @@ if (!class_exists('PEAR'))
   return;
 }
 
-require_once dirname(__FILE__).'/sfPearDownloaderTest.class.php';
-require_once dirname(__FILE__).'/sfPearRestTest.class.php';
-require_once dirname(__FILE__).'/sfPluginTestHelper.class.php';
+require_once __DIR__.'/sfPearDownloaderTest.class.php';
+require_once __DIR__.'/sfPearRestTest.class.php';
+require_once __DIR__.'/sfPluginTestHelper.class.php';
 
 // setup
 $temp = tempnam('/tmp/sf_plugin_test', 'tmp');
@@ -170,7 +170,7 @@ $t->is(file_get_contents($temp.'/plugins/sfTestPlugin/VERSION'), '1.1.4', '->ins
 $t->ok($pluginManager->uninstallPlugin('sfTestPlugin'), '->uninstallPlugin() returns true if the plugin is properly uninstalled');
 $t->ok(!is_file($temp.'/plugins/sfTestPlugin/VERSION'), '->uninstallPlugin() uninstalls a plugin');
 
-$pluginManager->installPlugin(dirname(__FILE__).'/fixtures/http/pear.example.com/get/sfTestPlugin/sfTestPlugin-1.1.4.tgz');
+$pluginManager->installPlugin(__DIR__.'/fixtures/http/pear.example.com/get/sfTestPlugin/sfTestPlugin-1.1.4.tgz');
 $t->is(file_get_contents($temp.'/plugins/sfTestPlugin/VERSION'), '1.1.4', '->installPlugin() can install a local PEAR package');
 
 $t->ok($pluginManager->uninstallPlugin('sfTestPlugin'), '->uninstallPlugin() returns true if the plugin is properly uninstalled');

--- a/test/unit/plugin/sfPluginTestHelper.class.php
+++ b/test/unit/plugin/sfPluginTestHelper.class.php
@@ -16,12 +16,12 @@ class sfPluginTestHelper
       mkdir(dirname($dest), 0777, true);
     }
 
-    if (!file_exists(dirname(__FILE__).'/fixtures/'.$dir.'/'.$file))
+    if (!file_exists(__DIR__.'/fixtures/'.$dir.'/'.$file))
     {
       throw new sfException(sprintf('Unable to find fixture for %s (%s)', $url, $file));
     }
 
-    copy(dirname(__FILE__).'/fixtures/'.$dir.'/'.$file, $dest);
+    copy(__DIR__.'/fixtures/'.$dir.'/'.$file, $dest);
 
     return $dest;
   }

--- a/test/unit/request/sfRequestTest.php
+++ b/test/unit/request/sfRequestTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class myRequest extends sfRequest
 {

--- a/test/unit/request/sfWebRequestTest.php
+++ b/test/unit/request/sfWebRequestTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(109);
 

--- a/test/unit/response/sfResponseTest.php
+++ b/test/unit/response/sfResponseTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class myResponse extends sfResponse
 {

--- a/test/unit/response/sfWebResponseTest.php
+++ b/test/unit/response/sfWebResponseTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(89);
 

--- a/test/unit/routing/sfObjectRouteCollectionTest.php
+++ b/test/unit/routing/sfObjectRouteCollectionTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(25);
 

--- a/test/unit/routing/sfObjectRouteTest.php
+++ b/test/unit/routing/sfObjectRouteTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/routing/sfPatternRoutingTest.php
+++ b/test/unit/routing/sfPatternRoutingTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(149);
 
@@ -41,7 +41,7 @@ class sfPatternRoutingTest extends sfPatternRouting
 
   protected function getConfigFileName()
   {
-    return dirname(__FILE__).'/fixtures/config_routing.yml.php';
+    return __DIR__.'/fixtures/config_routing.yml.php';
   }
 }
 

--- a/test/unit/routing/sfRequestRouteTest.php
+++ b/test/unit/routing/sfRequestRouteTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(8);
 

--- a/test/unit/routing/sfRouteTest.php
+++ b/test/unit/routing/sfRouteTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(65);
 

--- a/test/unit/service/fixtures/containers/container10.php
+++ b/test/unit/service/fixtures/containers/container10.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname(__FILE__).'/../includes/classes.php';
+require_once __DIR__.'/../includes/classes.php';
 
 $container = new sfServiceContainerBuilder();
 $container->

--- a/test/unit/service/fixtures/containers/container9.php
+++ b/test/unit/service/fixtures/containers/container9.php
@@ -1,13 +1,13 @@
 <?php
 
-require_once dirname(__FILE__).'/../includes/classes.php';
+require_once __DIR__.'/../includes/classes.php';
 
 $container = new sfServiceContainerBuilder();
 $container->
   register('foo', 'FooClass')->
   setConstructor('getInstance')->
   setArguments(array('foo', new sfServiceReference('foo.baz'), array('%foo%' => 'foo is %foo%'), true, new sfServiceReference('service_container')))->
-  setFile(realpath(dirname(__FILE__).'/../includes/foo.php'))->
+  setFile(realpath(__DIR__.'/../includes/foo.php'))->
   setShared(false)->
   addMethodCall('setBar', array('bar'))->
   addMethodCall('initialize')->

--- a/test/unit/service/sfServiceContainerBuilderTest.php
+++ b/test/unit/service/sfServiceContainerBuilderTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(48);
 
@@ -124,9 +124,9 @@ $t->is($builder->getServiceIds(), array('foo', 'bar', 'service_container'), '->g
 // ->createService() # file
 $t->diag('->createService() # file');
 $builder = new sfServiceContainerBuilder();
-$builder->register('foo1', 'FooClass')->setFile(dirname(__FILE__).'/fixtures/includes/foo.php');
+$builder->register('foo1', 'FooClass')->setFile(__DIR__.'/fixtures/includes/foo.php');
 $t->ok($builder->getService('foo1'), '->createService() requires the file defined by the service definition');
-$builder->register('foo2', 'FooClass')->setFile(dirname(__FILE__).'/fixtures/includes/%file%.php');
+$builder->register('foo2', 'FooClass')->setFile(__DIR__.'/fixtures/includes/%file%.php');
 $builder->setParameter('file', 'foo');
 $t->ok($builder->getService('foo2'), '->createService() replaces parameters in the file provided by the service definition');
 
@@ -163,7 +163,7 @@ $builder->setParameter('value', 'bar');
 $t->is($builder->getService('foo1')->bar, array('bar', $builder->getService('bar')), '->createService() replaces the values in the method calls arguments');
 
 // ->createService() # configurator
-require_once dirname(__FILE__).'/fixtures/includes/classes.php';
+require_once __DIR__.'/fixtures/includes/classes.php';
 $t->diag('->createService() # configurator');
 $builder = new sfServiceContainerBuilder();
 $builder->register('foo1', 'FooClass')->setConfigurator('sc_configure');

--- a/test/unit/service/sfServiceContainerDumperGraphvizTest.php
+++ b/test/unit/service/sfServiceContainerDumperGraphvizTest.php
@@ -8,11 +8,11 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(4);
 
-$dir = dirname(__FILE__).'/fixtures/graphviz';
+$dir = __DIR__.'/fixtures/graphviz';
 
 
 // ->dump()
@@ -24,15 +24,15 @@ $t->is($dumper->dump(), file_get_contents($dir.'/services1.dot'), '->dump() dump
 $container = new sfServiceContainerBuilder();
 $dumper = new sfServiceContainerDumperGraphviz($container);
 
-$container = include dirname(__FILE__).'/fixtures/containers/container9.php';
+$container = include __DIR__.'/fixtures/containers/container9.php';
 $dumper = new sfServiceContainerDumperGraphviz($container);
-$t->is($dumper->dump(), str_replace('%path%', dirname(__FILE__), file_get_contents($dir.'/services9.dot')), '->dump() dumps services');
+$t->is($dumper->dump(), str_replace('%path%', __DIR__, file_get_contents($dir.'/services9.dot')), '->dump() dumps services');
 
-$container = include dirname(__FILE__).'/fixtures/containers/container10.php';
+$container = include __DIR__.'/fixtures/containers/container10.php';
 $dumper = new sfServiceContainerDumperGraphviz($container);
-$t->is($dumper->dump(), str_replace('%path%', dirname(__FILE__), file_get_contents($dir.'/services10.dot')), '->dump() dumps services');
+$t->is($dumper->dump(), str_replace('%path%', __DIR__, file_get_contents($dir.'/services10.dot')), '->dump() dumps services');
 
-$container = include dirname(__FILE__).'/fixtures/containers/container10.php';
+$container = include __DIR__.'/fixtures/containers/container10.php';
 $dumper = new sfServiceContainerDumperGraphviz($container);
 $t->is($dumper->dump(array(
   'graph' => array('ratio' => 'normal'),
@@ -41,4 +41,4 @@ $t->is($dumper->dump(array(
   'node.instance' => array('fillcolor' => 'green', 'style' => 'empty'),
   'node.definition' => array('fillcolor' => 'grey'),
   'node.missing' => array('fillcolor' => 'red', 'style' => 'empty'),
-)), str_replace('%path%', dirname(__FILE__), file_get_contents($dir.'/services10-1.dot')), '->dump() dumps services');
+)), str_replace('%path%', __DIR__, file_get_contents($dir.'/services10-1.dot')), '->dump() dumps services');

--- a/test/unit/service/sfServiceContainerDumperPhpTest.php
+++ b/test/unit/service/sfServiceContainerDumperPhpTest.php
@@ -8,11 +8,11 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(5);
 
-$dir = dirname(__FILE__).'/fixtures/php';
+$dir = __DIR__.'/fixtures/php';
 
 
 // ->dump()
@@ -27,15 +27,15 @@ $dumper = new sfServiceContainerDumperPhp($container);
 
 // ->addParameters()
 $t->diag('->addParameters()');
-$container = include dirname(__FILE__).'/fixtures/containers/container8.php';
+$container = include __DIR__.'/fixtures/containers/container8.php';
 $dumper = new sfServiceContainerDumperPhp($container);
 $t->is($dumper->dump(), file_get_contents($dir.'/services8.php'), '->dump() dumps parameters');
 
 // ->addService()
 $t->diag('->addService()');
-$container = include dirname(__FILE__).'/fixtures/containers/container9.php';
+$container = include __DIR__.'/fixtures/containers/container9.php';
 $dumper = new sfServiceContainerDumperPhp($container);
-$t->is($dumper->dump(), str_replace('%path%', dirname(__FILE__).'/fixtures/includes', file_get_contents($dir.'/services9.php')), '->dump() dumps services');
+$t->is($dumper->dump(), str_replace('%path%', __DIR__.'/fixtures/includes', file_get_contents($dir.'/services9.php')), '->dump() dumps services');
 
 $dumper = new sfServiceContainerDumperPhp($container = new sfServiceContainerBuilder());
 $container->register('foo', 'FooClass')->addArgument(new stdClass());

--- a/test/unit/service/sfServiceContainerDumperTest.php
+++ b/test/unit/service/sfServiceContainerDumperTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/service/sfServiceContainerLoaderArrayTest.php
+++ b/test/unit/service/sfServiceContainerLoaderArrayTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(20);
 
@@ -25,7 +25,7 @@ $loader = new ProjectLoader(null);
 // ->validate()
 try
 {
-  $loader->validate(sfYaml::load(dirname(__FILE__).'/fixtures/yaml/nonvalid1.yml'));
+  $loader->validate(sfYaml::load(__DIR__.'/fixtures/yaml/nonvalid1.yml'));
   $t->fail('->validate() throws an InvalidArgumentException if the loaded definition is not an array');
 }
 catch (InvalidArgumentException $e)
@@ -35,7 +35,7 @@ catch (InvalidArgumentException $e)
 
 try
 {
-  $loader->validate(sfYaml::load(dirname(__FILE__).'/fixtures/yaml/nonvalid2.yml'));
+  $loader->validate(sfYaml::load(__DIR__.'/fixtures/yaml/nonvalid2.yml'));
   $t->fail('->validate() throws an InvalidArgumentException if the loaded definition is not a valid array');
 }
 catch (InvalidArgumentException $e)
@@ -49,15 +49,15 @@ $t->diag('->load() # parameters');
 list($services, $parameters) = $loader->doLoad(array());
 $t->is($parameters, array(), '->load() return emty parameters array for an empty array definition');
 
-list($services, $parameters) = $loader->doLoad(sfYaml::load(dirname(__FILE__).'/fixtures/yaml/services2.yml'));
+list($services, $parameters) = $loader->doLoad(sfYaml::load(__DIR__.'/fixtures/yaml/services2.yml'));
 $t->is($parameters, array('foo' => 'bar', 'values' => array(true, false, 0, 1000.3), 'bar' => 'foo', 'foo_bar' => new sfServiceReference('foo_bar')), '->load() converts array keys to lowercase');
 
 // ->load() # services
-list($services, $parameters) = $loader->doLoad(sfYaml::load(dirname(__FILE__).'/fixtures/yaml/services2.yml'));
+list($services, $parameters) = $loader->doLoad(sfYaml::load(__DIR__.'/fixtures/yaml/services2.yml'));
 $t->is($services, array(), '->load() return emty services array for an empty array definition');
 
 $t->diag('->load() # services');
-list($services, $parameters) = $loader->doLoad(sfYaml::load(dirname(__FILE__).'/fixtures/yaml/services3.yml'));
+list($services, $parameters) = $loader->doLoad(sfYaml::load(__DIR__.'/fixtures/yaml/services3.yml'));
 $t->ok(isset($services['foo']), '->load() parses service elements');
 $t->is(get_class($services['foo']), 'sfServiceDefinition', '->load() converts service element to sfServiceDefinition instances');
 $t->is($services['foo']->getClass(), 'FooClass', '->load() parses the class attribute');

--- a/test/unit/service/sfServiceContainerLoaderTest.php
+++ b/test/unit/service/sfServiceContainerLoaderTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(11);
 

--- a/test/unit/service/sfServiceContainerTest.php
+++ b/test/unit/service/sfServiceContainerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(27);
 

--- a/test/unit/service/sfServiceDefinitionTest.php
+++ b/test/unit/service/sfServiceDefinitionTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(21);
 

--- a/test/unit/service/sfServiceParameterTest.php
+++ b/test/unit/service/sfServiceParameterTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/service/sfServiceReferenceTest.php
+++ b/test/unit/service/sfServiceReferenceTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/storage/sfCacheSessionStorageTest.php
+++ b/test/unit/storage/sfCacheSessionStorageTest.php
@@ -10,9 +10,9 @@
 
 $app = 'frontend';
 
-require_once(dirname(__FILE__).'/../../bootstrap/functional.php');
+require_once(__DIR__.'/../../bootstrap/functional.php');
 
-$_test_dir = realpath(dirname(__FILE__).'/../../');
+$_test_dir = realpath(__DIR__.'/../../');
 require_once($_test_dir.'/../lib/vendor/lime/lime.php');
 
 sfConfig::set('sf_symfony_lib_dir', realpath($_test_dir.'/../lib'));

--- a/test/unit/storage/sfMySQLStorageTest.php
+++ b/test/unit/storage/sfMySQLStorageTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 ob_start();
 $plan = 16;

--- a/test/unit/storage/sfMySQLiStorageTest.php
+++ b/test/unit/storage/sfMySQLiStorageTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 ob_start();
 $plan = 12;

--- a/test/unit/storage/sfNoStorageTest.php
+++ b/test/unit/storage/sfNoStorageTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/storage/sfPDOSessionStorageTest.php
+++ b/test/unit/storage/sfPDOSessionStorageTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 ob_start();
 $plan = 15;

--- a/test/unit/storage/sfSessionStorageTest.php
+++ b/test/unit/storage/sfSessionStorageTest.php
@@ -10,11 +10,11 @@
 
 $app = 'frontend';
 
-require_once(dirname(__FILE__).'/../../bootstrap/functional.php');
+require_once(__DIR__.'/../../bootstrap/functional.php');
 
 ob_start();
 
-$_test_dir = realpath(dirname(__FILE__).'/../../');
+$_test_dir = realpath(__DIR__.'/../../');
 require_once($_test_dir.'/../lib/vendor/lime/lime.php');
 
 sfConfig::set('sf_symfony_lib_dir', realpath($_test_dir.'/../lib'));

--- a/test/unit/storage/sfStorageTest.php
+++ b/test/unit/storage/sfStorageTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(0);
 

--- a/test/unit/task/cache/sfCacheClearTaskTest.php
+++ b/test/unit/task/cache/sfCacheClearTaskTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/task.php');
+require_once(__DIR__.'/../../../bootstrap/task.php');
 
 $t = new lime_test(2);
 

--- a/test/unit/task/sfBaseTaskTest.php
+++ b/test/unit/task/sfBaseTaskTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-include dirname(__FILE__).'/../../bootstrap/unit.php';
+include __DIR__.'/../../bootstrap/unit.php';
 require_once sfConfig::get('sf_symfony_lib_dir').'/vendor/lime/lime.php';
 
 class TestTask extends sfBaseTask
@@ -28,7 +28,7 @@ class TestTask extends sfBaseTask
   }
 }
 
-$rootDir = dirname(__FILE__).'/../../functional/fixtures';
+$rootDir = __DIR__.'/../../functional/fixtures';
 sfToolkit::clearDirectory($rootDir.'/cache');
 
 $dispatcher = new sfEventDispatcher();

--- a/test/unit/task/sfFilesystemTest.php
+++ b/test/unit/task/sfFilesystemTest.php
@@ -7,7 +7,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 //lazy constant, cause it is so often used in this test
 define("DS", DIRECTORY_SEPARATOR);

--- a/test/unit/task/sfTaskTest.php
+++ b/test/unit/task/sfTaskTest.php
@@ -7,7 +7,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-require_once dirname(__FILE__).'/../../bootstrap/unit.php';
+require_once __DIR__.'/../../bootstrap/unit.php';
 
 $t = new lime_test(16);
 

--- a/test/unit/test/sfTestFunctionalTest.php
+++ b/test/unit/test/sfTestFunctionalTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(2);
 

--- a/test/unit/user/sfBasicSecurityUserTest.php
+++ b/test/unit/user/sfBasicSecurityUserTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(47);
 

--- a/test/unit/user/sfUserTest.php
+++ b/test/unit/user/sfUserTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(32);
 

--- a/test/unit/util/sfBrowserTest.php
+++ b/test/unit/util/sfBrowserTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(74);
 

--- a/test/unit/util/sfCallableTest.php
+++ b/test/unit/util/sfCallableTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(5);
 

--- a/test/unit/util/sfClassManipulatorTest.php
+++ b/test/unit/util/sfClassManipulatorTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(18);
 

--- a/test/unit/util/sfContextTest.php
+++ b/test/unit/util/sfContextTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(29);
 
@@ -33,7 +33,7 @@ class frontendConfiguration extends sfApplicationConfiguration
 */
 
 // use functional project configruration
-require_once realpath(dirname(__FILE__).'/../../functional/fixtures/config/ProjectConfiguration.class.php');
+require_once realpath(__DIR__.'/../../functional/fixtures/config/ProjectConfiguration.class.php');
 
 $frontend_context = sfContext::createInstance(ProjectConfiguration::getApplicationConfiguration('frontend', 'test', true));
 $frontend_context_prod = sfContext::createInstance(ProjectConfiguration::getApplicationConfiguration('frontend', 'prod', false));

--- a/test/unit/util/sfDomCssSelectorTest.php
+++ b/test/unit/util/sfDomCssSelectorTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(72);
 

--- a/test/unit/util/sfFinderTest.php
+++ b/test/unit/util/sfFinderTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class my_lime_test extends lime_test
 {
@@ -24,7 +24,7 @@ $t = new my_lime_test(39);
 
 require_once($_test_dir.'/../lib/util/sfFinder.class.php');
 
-$fixtureDir = dirname(__FILE__).'/fixtures/finder';
+$fixtureDir = __DIR__.'/fixtures/finder';
 $phpFiles = array(
   'dir1/dir2/file21.php',
   'dir1/file12.php',

--- a/test/unit/util/sfInflectorTest.php
+++ b/test/unit/util/sfInflectorTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/../lib/util/sfToolkit.class.php');
 require_once($_test_dir.'/../lib/util/sfInflector.class.php');
 

--- a/test/unit/util/sfNamespacedParameterHolderTest.php
+++ b/test/unit/util/sfNamespacedParameterHolderTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(50);
 

--- a/test/unit/util/sfParameterHolderTest.php
+++ b/test/unit/util/sfParameterHolderTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(24);
 

--- a/test/unit/util/sfToolkitTest.php
+++ b/test/unit/util/sfToolkitTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(95);
 
@@ -225,27 +225,27 @@ $t->is(sfToolkit::getArrayValueForPath($arr, 'foo[bar][baz][booze]'), null, '::g
 // ::addIncludePath()
 $t->diag('::addIncludePath()');
 $path = get_include_path();
-$t->is(sfToolkit::addIncludePath(dirname(__FILE__)), $path, '::addIncludePath() returns the previous include_path');
-$t->is(get_include_path(), dirname(__FILE__).PATH_SEPARATOR.$path, '::addIncludePath() adds a path to the front of include_path');
+$t->is(sfToolkit::addIncludePath(__DIR__), $path, '::addIncludePath() returns the previous include_path');
+$t->is(get_include_path(), __DIR__.PATH_SEPARATOR.$path, '::addIncludePath() adds a path to the front of include_path');
 
-sfToolkit::addIncludePath(dirname(__FILE__), 'back');
-$t->is(get_include_path(), $path.PATH_SEPARATOR.dirname(__FILE__), '::addIncludePath() moves a path to the end of include_path');
+sfToolkit::addIncludePath(__DIR__, 'back');
+$t->is(get_include_path(), $path.PATH_SEPARATOR.__DIR__, '::addIncludePath() moves a path to the end of include_path');
 
 sfToolkit::addIncludePath(array(
-  dirname(__FILE__),
-  dirname(__FILE__).'/..',
+  __DIR__,
+  __DIR__.'/..',
 ));
-$t->is(get_include_path(), dirname(__FILE__).PATH_SEPARATOR.dirname(__FILE__).'/..'.PATH_SEPARATOR.$path, '::addIncludePath() adds multiple paths the the front of include_path');
+$t->is(get_include_path(), __DIR__.PATH_SEPARATOR.__DIR__.'/..'.PATH_SEPARATOR.$path, '::addIncludePath() adds multiple paths the the front of include_path');
 
 sfToolkit::addIncludePath(array(
-  dirname(__FILE__),
-  dirname(__FILE__).'/..',
+  __DIR__,
+  __DIR__.'/..',
 ), 'back');
-$t->is(get_include_path(), $path.PATH_SEPARATOR.dirname(__FILE__).PATH_SEPARATOR.dirname(__FILE__).'/..', '::addIncludePath() adds multiple paths the the back of include_path');
+$t->is(get_include_path(), $path.PATH_SEPARATOR.__DIR__.PATH_SEPARATOR.__DIR__.'/..', '::addIncludePath() adds multiple paths the the back of include_path');
 
 try
 {
-  sfToolkit::addIncludePath(dirname(__FILE__), 'foobar');
+  sfToolkit::addIncludePath(__DIR__, 'foobar');
   $t->fail('::addIncludePath() throws an exception if position is not valid');
 }
 catch (Exception $e)

--- a/test/unit/validator/i18n/sfValidatorI18nChoiceCountryTest.php
+++ b/test/unit/validator/i18n/sfValidatorI18nChoiceCountryTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(3);
 

--- a/test/unit/validator/i18n/sfValidatorI18nChoiceLanguageTest.php
+++ b/test/unit/validator/i18n/sfValidatorI18nChoiceLanguageTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(3);
 

--- a/test/unit/validator/i18n/sfValidatorI18nChoiceTimezoneTest.php
+++ b/test/unit/validator/i18n/sfValidatorI18nChoiceTimezoneTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/validator/sfValidatorAndTest.php
+++ b/test/unit/validator/sfValidatorAndTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(25);
 

--- a/test/unit/validator/sfValidatorBaseTest.php
+++ b/test/unit/validator/sfValidatorBaseTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(47);
 

--- a/test/unit/validator/sfValidatorBooleanTest.php
+++ b/test/unit/validator/sfValidatorBooleanTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(17);
 

--- a/test/unit/validator/sfValidatorCSRFTokenTest.php
+++ b/test/unit/validator/sfValidatorCSRFTokenTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(5);
 

--- a/test/unit/validator/sfValidatorCallbackTest.php
+++ b/test/unit/validator/sfValidatorCallbackTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(7);
 

--- a/test/unit/validator/sfValidatorChoiceTest.php
+++ b/test/unit/validator/sfValidatorChoiceTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(14);
 

--- a/test/unit/validator/sfValidatorDateRangeTest.php
+++ b/test/unit/validator/sfValidatorDateRangeTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(7);
 

--- a/test/unit/validator/sfValidatorDateTest.php
+++ b/test/unit/validator/sfValidatorDateTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(52);
 

--- a/test/unit/validator/sfValidatorDateTimeTest.php
+++ b/test/unit/validator/sfValidatorDateTimeTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(4);
 

--- a/test/unit/validator/sfValidatorDecoratorTest.php
+++ b/test/unit/validator/sfValidatorDecoratorTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(20);
 

--- a/test/unit/validator/sfValidatorEmailTest.php
+++ b/test/unit/validator/sfValidatorEmailTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(11);
 

--- a/test/unit/validator/sfValidatorEqualTest.php
+++ b/test/unit/validator/sfValidatorEqualTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(9);
 

--- a/test/unit/validator/sfValidatorErrorSchemaTest.php
+++ b/test/unit/validator/sfValidatorErrorSchemaTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(33);
 

--- a/test/unit/validator/sfValidatorErrorTest.php
+++ b/test/unit/validator/sfValidatorErrorTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(14);
 

--- a/test/unit/validator/sfValidatorFileTest.php
+++ b/test/unit/validator/sfValidatorFileTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(69);
 

--- a/test/unit/validator/sfValidatorFromDescriptionTest.php
+++ b/test/unit/validator/sfValidatorFromDescriptionTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(98);
 

--- a/test/unit/validator/sfValidatorIntegerTest.php
+++ b/test/unit/validator/sfValidatorIntegerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(15);
 

--- a/test/unit/validator/sfValidatorIpTest.php
+++ b/test/unit/validator/sfValidatorIpTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $validV4Ips = array(
   '0.0.0.0',

--- a/test/unit/validator/sfValidatorNumberTest.php
+++ b/test/unit/validator/sfValidatorNumberTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(13);
 

--- a/test/unit/validator/sfValidatorOrTest.php
+++ b/test/unit/validator/sfValidatorOrTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(18);
 

--- a/test/unit/validator/sfValidatorPassTest.php
+++ b/test/unit/validator/sfValidatorPassTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(2);
 

--- a/test/unit/validator/sfValidatorRegexTest.php
+++ b/test/unit/validator/sfValidatorRegexTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 function generate_regex()
 {

--- a/test/unit/validator/sfValidatorSchemaCompareTest.php
+++ b/test/unit/validator/sfValidatorSchemaCompareTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(114);
 

--- a/test/unit/validator/sfValidatorSchemaFilterTest.php
+++ b/test/unit/validator/sfValidatorSchemaFilterTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(6);
 

--- a/test/unit/validator/sfValidatorSchemaTest.php
+++ b/test/unit/validator/sfValidatorSchemaTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(85);
 

--- a/test/unit/validator/sfValidatorStringTest.php
+++ b/test/unit/validator/sfValidatorStringTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(12);
 

--- a/test/unit/validator/sfValidatorTimeTest.php
+++ b/test/unit/validator/sfValidatorTimeTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(27);
 

--- a/test/unit/validator/sfValidatorUrlTest.php
+++ b/test/unit/validator/sfValidatorUrlTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(15);
 

--- a/test/unit/view/sfViewCacheManagerTest.php
+++ b/test/unit/view/sfViewCacheManagerTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 
 $t = new lime_test(41);

--- a/test/unit/view/sfViewParameterHolderTest.php
+++ b/test/unit/view/sfViewParameterHolderTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 
 $t = new lime_test(21);

--- a/test/unit/view/sfViewTest.php
+++ b/test/unit/view/sfViewTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 require_once($_test_dir.'/unit/sfContextMock.class.php');
 
 $t = new lime_test(19);

--- a/test/unit/widget/i18n/sfWidgetFormI18nChoiceCountryTest.php
+++ b/test/unit/widget/i18n/sfWidgetFormI18nChoiceCountryTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(8);
 

--- a/test/unit/widget/i18n/sfWidgetFormI18nChoiceCurrencyTest.php
+++ b/test/unit/widget/i18n/sfWidgetFormI18nChoiceCurrencyTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(7);
 

--- a/test/unit/widget/i18n/sfWidgetFormI18nChoiceLanguageTest.php
+++ b/test/unit/widget/i18n/sfWidgetFormI18nChoiceLanguageTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(6);
 

--- a/test/unit/widget/i18n/sfWidgetFormI18nChoiceTimezoneTest.php
+++ b/test/unit/widget/i18n/sfWidgetFormI18nChoiceTimezoneTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(4);
 

--- a/test/unit/widget/i18n/sfWidgetFormI18nDateTest.php
+++ b/test/unit/widget/i18n/sfWidgetFormI18nDateTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(7);
 

--- a/test/unit/widget/i18n/sfWidgetFormI18nDateTimeTest.php
+++ b/test/unit/widget/i18n/sfWidgetFormI18nDateTimeTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/widget/i18n/sfWidgetFormI18nTimeTest.php
+++ b/test/unit/widget/i18n/sfWidgetFormI18nTimeTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../../bootstrap/unit.php');
+require_once(__DIR__.'/../../../bootstrap/unit.php');
 
 $t = new lime_test(4);
 

--- a/test/unit/widget/sfWidgetFormChoiceTest.php
+++ b/test/unit/widget/sfWidgetFormChoiceTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class FormFormatterStub extends sfWidgetFormSchemaFormatter
 {

--- a/test/unit/widget/sfWidgetFormDateRangeTest.php
+++ b/test/unit/widget/sfWidgetFormDateRangeTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class FormFormatterMock extends sfWidgetFormSchemaFormatter
 {

--- a/test/unit/widget/sfWidgetFormDateTest.php
+++ b/test/unit/widget/sfWidgetFormDateTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $year = date('Y');
 

--- a/test/unit/widget/sfWidgetFormDateTimeTest.php
+++ b/test/unit/widget/sfWidgetFormDateTimeTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $year = date('Y');
 

--- a/test/unit/widget/sfWidgetFormFilterDateTest.php
+++ b/test/unit/widget/sfWidgetFormFilterDateTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class FormFormatterStub extends sfWidgetFormSchemaFormatter
 {

--- a/test/unit/widget/sfWidgetFormFilterInputTest.php
+++ b/test/unit/widget/sfWidgetFormFilterInputTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class FormFormatterStub extends sfWidgetFormSchemaFormatter
 {

--- a/test/unit/widget/sfWidgetFormInputCheckboxTest.php
+++ b/test/unit/widget/sfWidgetFormInputCheckboxTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(7);
 

--- a/test/unit/widget/sfWidgetFormInputFileEditableTest.php
+++ b/test/unit/widget/sfWidgetFormInputFileEditableTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class FormFormatterStub extends sfWidgetFormSchemaFormatter
 {

--- a/test/unit/widget/sfWidgetFormInputFileTest.php
+++ b/test/unit/widget/sfWidgetFormInputFileTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/widget/sfWidgetFormInputHiddenTest.php
+++ b/test/unit/widget/sfWidgetFormInputHiddenTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(2);
 

--- a/test/unit/widget/sfWidgetFormInputPasswordTest.php
+++ b/test/unit/widget/sfWidgetFormInputPasswordTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(3);
 

--- a/test/unit/widget/sfWidgetFormInputReadTest.php
+++ b/test/unit/widget/sfWidgetFormInputReadTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(6);
 

--- a/test/unit/widget/sfWidgetFormInputTextTest.php
+++ b/test/unit/widget/sfWidgetFormInputTextTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(5);
 

--- a/test/unit/widget/sfWidgetFormSchemaDecoratorTest.php
+++ b/test/unit/widget/sfWidgetFormSchemaDecoratorTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(16);
 

--- a/test/unit/widget/sfWidgetFormSchemaFormatterListTest.php
+++ b/test/unit/widget/sfWidgetFormSchemaFormatterListTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(2);
 

--- a/test/unit/widget/sfWidgetFormSchemaFormatterTableTest.php
+++ b/test/unit/widget/sfWidgetFormSchemaFormatterTableTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(2);
 

--- a/test/unit/widget/sfWidgetFormSchemaFormatterTest.php
+++ b/test/unit/widget/sfWidgetFormSchemaFormatterTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(28);
 

--- a/test/unit/widget/sfWidgetFormSchemaTest.php
+++ b/test/unit/widget/sfWidgetFormSchemaTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(95);
 

--- a/test/unit/widget/sfWidgetFormSelectCheckboxTest.php
+++ b/test/unit/widget/sfWidgetFormSelectCheckboxTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class FormFormatterStub extends sfWidgetFormSchemaFormatter
 {

--- a/test/unit/widget/sfWidgetFormSelectManyTest.php
+++ b/test/unit/widget/sfWidgetFormSelectManyTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(1);
 

--- a/test/unit/widget/sfWidgetFormSelectRadioTest.php
+++ b/test/unit/widget/sfWidgetFormSelectRadioTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class FormFormatterStub extends sfWidgetFormSchemaFormatter
 {

--- a/test/unit/widget/sfWidgetFormSelectTest.php
+++ b/test/unit/widget/sfWidgetFormSelectTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class FormFormatterStub extends sfWidgetFormSchemaFormatter
 {

--- a/test/unit/widget/sfWidgetFormTest.php
+++ b/test/unit/widget/sfWidgetFormTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(35);
 

--- a/test/unit/widget/sfWidgetFormTextareaTest.php
+++ b/test/unit/widget/sfWidgetFormTextareaTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(4);
 

--- a/test/unit/widget/sfWidgetFormTimeTest.php
+++ b/test/unit/widget/sfWidgetFormTimeTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(43);
 

--- a/test/unit/widget/sfWidgetTest.php
+++ b/test/unit/widget/sfWidgetTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 $t = new lime_test(33);
 

--- a/test/unit/yaml/sfYamlDumperTest.php
+++ b/test/unit/yaml/sfYamlDumperTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 sfYaml::setSpecVersion('1.1');
 
@@ -17,7 +17,7 @@ $t = new lime_test(149);
 $parser = new sfYamlParser();
 $dumper = new sfYamlDumper();
 
-$path = dirname(__FILE__).'/fixtures';
+$path = __DIR__.'/fixtures';
 $files = $parser->parse(file_get_contents($path.'/index.yml'));
 foreach ($files as $file)
 {

--- a/test/unit/yaml/sfYamlInlineTest.php
+++ b/test/unit/yaml/sfYamlInlineTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 sfYaml::setSpecVersion('1.1');
 

--- a/test/unit/yaml/sfYamlParserTest.php
+++ b/test/unit/yaml/sfYamlParserTest.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
+require_once(__DIR__.'/../../bootstrap/unit.php');
 
 sfYaml::setSpecVersion('1.1');
 
@@ -16,7 +16,7 @@ $t = new lime_test(150);
 
 $parser = new sfYamlParser();
 
-$path = dirname(__FILE__).'/fixtures';
+$path = __DIR__.'/fixtures';
 $files = $parser->parse(file_get_contents($path.'/index.yml'));
 foreach ($files as $file)
 {


### PR DESCRIPTION
Since PHP 5.3.4 is now the requirement, the `__DIR__` magic constant can be used instead of `dirname(__FILE__)` for a little extra performance.
