### PR TITLE
PHP built-in webserver compatibility

### DIFF
--- a/lib/config/sfApplicationConfiguration.class.php
+++ b/lib/config/sfApplicationConfiguration.class.php
@@ -288,7 +288,7 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
       'sf_app'         => $this->getApplication(),
       'sf_environment' => $this->getEnvironment(),
       'sf_debug'       => $this->isDebug(),
-      'sf_cli'         => 0 === strncasecmp(PHP_SAPI, 'cli', 3)
+      'sf_cli'         => PHP_SAPI === 'cli',
     ));
 
     $this->setAppDir(sfConfig::get('sf_apps_dir').DIRECTORY_SEPARATOR.$this->getApplication());


### PR DESCRIPTION
`sf_cli` should be `false` when running with PHP built-in webserver (PHP_SAPI == "cli-server"). It is a web-environment, not CLI, though it is initiated with CLI command.
