### PR TITLE
Issue #65: Add again Propel from sfDatabaseSessionStorage

### DIFF
--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -101,7 +101,11 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
 
     // get the database and connection
     $databaseClass = get_class($database);
-    if ($databaseClass == 'sfDoctrineDatabase')
+    if ($databaseClass == 'sfPropelDatabase')
+    {    
+      $this->db = Propel::getConnection($database->getParameter('name'));    
+    }    
+    elseif($databaseClass == 'sfDoctrineDatabase')
     {
       $this->db = $database->getConnection();
     }


### PR DESCRIPTION
Rollback droping support for Propel sessions in database
