### PR TITLE
Use composer autoload

### DIFF
--- a/lib/task/generator/skeleton/project/config/ProjectConfiguration.class.php
+++ b/lib/task/generator/skeleton/project/config/ProjectConfiguration.class.php
@@ -1,7 +1,6 @@
 <?php
 
-require_once ##SYMFONY_CORE_AUTOLOAD##;
-sfCoreAutoload::register();
+require_once __DIR__ . '/../vendor/autoload.php';
 
 class ProjectConfiguration extends sfProjectConfiguration
 {


### PR DESCRIPTION
Replace symfony autoloader with composer autoloader in the new project skeleton.

While symfony 1.5 is not recommended for new production projects, it's still a handy tool for generating quick proof-of-concept projects.
