### PR TITLE
Add OPTIONS method for CORS

### DIFF
--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -27,6 +27,7 @@ abstract class sfRequest implements ArrayAccess
   const PUT    = 'PUT';
   const DELETE = 'DELETE';
   const HEAD   = 'HEAD';
+  const OPTIONS = 'OPTIONS';
 
   protected
     $dispatcher      = null,
@@ -147,7 +148,7 @@ abstract class sfRequest implements ArrayAccess
    */
   public function setMethod($method)
   {
-    if (!in_array(strtoupper($method), array(self::GET, self::POST, self::PUT, self::DELETE, self::HEAD)))
+    if (!in_array(strtoupper($method), array(self::GET, self::POST, self::PUT, self::DELETE, self::HEAD, self::OPTIONS)))
     {
       throw new sfException(sprintf('Invalid request method: %s.', $method));
     }

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -126,6 +126,10 @@ class sfWebRequest extends sfRequest
           $this->setMethod(self::HEAD);
           break;
 
+        case 'OPTIONS':
+          $this->setMethod(self::OPTIONS);
+          break;
+
         default:
           $this->setMethod(self::GET);
       }


### PR DESCRIPTION
To handle CORS requests, symfony must allow the OPTIONS method.
