### PR TITLE
Adds feature to declare optional services via @?service_name

### DIFF
--- a/lib/task/service/sfServicesGraphvizDumpTask.class.php
+++ b/lib/task/service/sfServicesGraphvizDumpTask.class.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the symfony package.
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Renders a service container dependencies into DOT file
+ *
+ * @package    symfony
+ * @subpackage task
+ * @author     Ilya Sabelnikov <fruit.dev@gmail.com>
+ * @version    SVN: $Id$
+ */
+class sfServicesGraphvizDumpTask extends sfBaseTask
+{
+  protected function configure()
+  {
+    $this->addOptions(
+      array(
+        new sfCommandOption(
+          'application',
+          null,
+          sfCommandOption::PARAMETER_REQUIRED,
+          'The application name',
+          'frontend'
+        ),
+        // add your own options here
+      )
+    );
+
+    $this->namespace = 'services';
+    $this->name = 'graphviz';
+    $this->briefDescription = 'Creates a Graphviz (.dot) file with the container dependencies';
+    $this->detailedDescription = <<<EOF
+Usage:
+
+    [./symfony {$this->namespace}:{$this->name}|INFO]
+EOF;
+  }
+
+  /**
+   * @param array $arguments
+   * @param array $options
+   *
+   * @return int
+   * @throws \sfFactoryException
+   */
+  protected function execute($arguments = array(), $options = array())
+  {
+    $configFiles = $this->configuration->getConfigPaths('config/services.yml');
+
+    $serviceContainerBuilder = new sfServiceContainerBuilder();
+    $loader = new sfServiceContainerLoaderArray($serviceContainerBuilder);
+    $loader->load(sfServiceConfigHandler::getConfiguration($configFiles));
+
+    $dumper = new sfServiceContainerDumperGraphviz($serviceContainerBuilder);
+
+    $dumpDir = sfConfig::get('sf_cache_dir') . '/service-container';
+
+    if (!is_dir($dumpDir))
+    {
+      if (!mkdir($dumpDir, 0777, true))
+      {
+        $this->logBlock(sprintf('Could not create temporary dir "%s"', $dumpDir), 'ERROR');
+        return 1;
+      }
+    }
+    $dotFile = sprintf('%s/%d-graphviz.dot', $dumpDir, time());
+
+    if (!file_put_contents($dotFile, $dumper->dump()))
+    {
+      $this->logBlock(sprintf('Could write content into file "%s"', $dotFile), 'ERROR');
+      return 2;
+    }
+
+    $this->logSection('+file', sprintf('Graphviz file created at %s', $dotFile));
+
+    return 0;
+  }
+}

--- a/test/unit/service/fixtures/containers/container11.php
+++ b/test/unit/service/fixtures/containers/container11.php
@@ -1,0 +1,18 @@
+<?php
+
+require_once __DIR__.'/../includes/classes.php';
+
+$container = new sfServiceContainerBuilder();
+$container->register('bar' , 'BarClass');
+$container
+    ->register('demo', 'ClassOptionalArguments')
+    ->addArgument(new sfServiceReference('bar'))
+    ->addArgument(new sfServiceReference('?bar'))
+    ->addMethodCall('setOptionalRegisteredObject', array(new sfServiceReference('?bar')))
+    ->addMethodCall('setRequiredRegisteredObject', array(new sfServiceReference('bar')))
+    ->addMethodCall('setOptionalMissingObject', array(new sfServiceReference('?missing_bar')))
+    ->addMethodCall('setRequiredMissingObject', array(new sfServiceReference('missing_bar')))
+    ->setConfigurator(array(new sfServiceReference('?missing_bar'), 'configure'))
+  ;
+
+return $container;

--- a/test/unit/service/fixtures/graphviz/services11.dot
+++ b/test/unit/service/fixtures/graphviz/services11.dot
@@ -1,0 +1,16 @@
+digraph sc {
+  ratio="compress"
+  node [fontsize="11" fontname="Arial" shape="record"];
+  edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
+
+  node_bar [label="bar\nBarClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_demo [label="demo\nClassOptionalArguments\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_service_container [label="service_container\nsfServiceContainerBuilder\n", shape=record, fillcolor="#9999ff", style="filled"];
+  node_missing_bar [label="missing_bar\n\n", shape=record, fillcolor="#ff9999", style="filled"];
+  node_demo -> node_bar [label="" style="filled"];
+  node_demo -> node_bar [label="" style="dashed"];
+  node_demo -> node_bar [label="setOptionalRegisteredObject()" style="dashed"];
+  node_demo -> node_bar [label="setRequiredRegisteredObject()" style="filled"];
+  node_demo -> node_missing_bar [label="setOptionalMissingObject()" style="dashed"];
+  node_demo -> node_missing_bar [label="setRequiredMissingObject()" style="filled"];
+}

--- a/test/unit/service/fixtures/includes/classes.php
+++ b/test/unit/service/fixtures/includes/classes.php
@@ -30,3 +30,35 @@ class BazClass
   {
   }
 }
+
+class MissingObjectClass
+{
+  public function configure($instance)
+  {
+
+  }
+}
+
+class ClassOptionalArguments
+{
+  public function __construct(BarClass $bar1, BarClass $bar2 = null)
+  {
+  }
+
+
+  public function setOptionalRegisteredObject(BarClass $bar = null) {
+
+  }
+
+  public function setRequiredRegisteredObject(BarClass $bar) {
+
+  }
+
+  public function setOptionalMissingObject(MissingObjectClass $missed = null) {
+
+  }
+
+  public function setRequiredMissingObject(MissingObjectClass $missed) {
+
+  }
+}

--- a/test/unit/service/fixtures/php/services11.php
+++ b/test/unit/service/fixtures/php/services11.php
@@ -1,0 +1,31 @@
+class ProjectServiceContainer extends sfServiceContainer
+{
+  protected $shared = array();
+
+  protected function getBarService()
+  {
+    if (isset($this->shared['bar'])) return $this->shared['bar'];
+
+    $instance = new BarClass();
+
+    return $this->shared['bar'] = $instance;
+  }
+
+  protected function getDemoService()
+  {
+    if (isset($this->shared['demo'])) return $this->shared['demo'];
+
+    $instance = new ClassOptionalArguments($this->getService('bar'), (! $this->hasService('bar') ? null : $this->getService('bar')));
+    $instance->setOptionalRegisteredObject((! $this->hasService('bar') ? null : $this->getService('bar')));
+    $instance->setRequiredRegisteredObject($this->getService('bar'));
+    $instance->setOptionalMissingObject((! $this->hasService('missing_bar') ? null : $this->getService('missing_bar')));
+    $instance->setRequiredMissingObject($this->getService('missing_bar'));
+    $configurator = (! $this->hasService('missing_bar') ? null : $this->getService('missing_bar'));
+    if (null !== $configurator)
+    {
+      $configurator->configure($instance);
+    }
+
+    return $this->shared['demo'] = $instance;
+  }
+}

--- a/test/unit/service/fixtures/yaml/services3.yml
+++ b/test/unit/service/fixtures/yaml/services3.yml
@@ -18,3 +18,5 @@ services:
     calls:
       - [ setBar, [ foo, @foo, [true, false] ] ]
   alias_for_foo: @foo
+  bar: { class: BarClass }
+  opt_args: { class: ClassOptionalArguments, arguments: ['@bar', '@?bar'] }

--- a/test/unit/service/sfServiceContainerDumperGraphvizTest.php
+++ b/test/unit/service/sfServiceContainerDumperGraphvizTest.php
@@ -10,7 +10,7 @@
 
 require_once(__DIR__.'/../../bootstrap/unit.php');
 
-$t = new lime_test(4);
+$t = new lime_test(5);
 
 $dir = __DIR__.'/fixtures/graphviz';
 
@@ -42,3 +42,7 @@ $t->is($dumper->dump(array(
   'node.definition' => array('fillcolor' => 'grey'),
   'node.missing' => array('fillcolor' => 'red', 'style' => 'empty'),
 )), str_replace('%path%', __DIR__, file_get_contents($dir.'/services10-1.dot')), '->dump() dumps services');
+
+$container = include __DIR__.'/fixtures/containers/container11.php';
+$dumper = new sfServiceContainerDumperGraphviz($container);
+$t->is($dumper->dump(), str_replace('%path%', __DIR__, file_get_contents($dir.'/services11.dot')), '->dump() dumps optional services');

--- a/test/unit/service/sfServiceContainerDumperPhpTest.php
+++ b/test/unit/service/sfServiceContainerDumperPhpTest.php
@@ -10,7 +10,7 @@
 
 require_once(__DIR__.'/../../bootstrap/unit.php');
 
-$t = new lime_test(5);
+$t = new lime_test(6);
 
 $dir = __DIR__.'/fixtures/php';
 
@@ -36,6 +36,12 @@ $t->diag('->addService()');
 $container = include __DIR__.'/fixtures/containers/container9.php';
 $dumper = new sfServiceContainerDumperPhp($container);
 $t->is($dumper->dump(), str_replace('%path%', __DIR__.'/fixtures/includes', file_get_contents($dir.'/services9.php')), '->dump() dumps services');
+
+// ->hasService()
+$t->diag('->hasService()');
+$container = include __DIR__.'/fixtures/containers/container11.php';
+$dumper = new sfServiceContainerDumperPhp($container);
+$t->is($dumper->dump(), file_get_contents($dir . '/services11.php'), '->dump() dumps optional services');
 
 $dumper = new sfServiceContainerDumperPhp($container = new sfServiceContainerBuilder());
 $container->register('foo', 'FooClass')->addArgument(new stdClass());

--- a/test/unit/service/sfServiceContainerLoaderArrayTest.php
+++ b/test/unit/service/sfServiceContainerLoaderArrayTest.php
@@ -10,7 +10,7 @@
 
 require_once(__DIR__.'/../../bootstrap/unit.php');
 
-$t = new lime_test(20);
+$t = new lime_test(21);
 
 class ProjectLoader extends sfServiceContainerLoaderArray
 {
@@ -73,3 +73,4 @@ $t->is($services['method_call1']->getMethodCalls(), array(array('setBar', array(
 $t->is($services['method_call2']->getMethodCalls(), array(array('setBar', array('foo', new sfServiceReference('foo'), array(true, false)))), '->load() parses the method_call tag');
 $t->ok(isset($services['alias_for_foo']), '->load() parses aliases');
 $t->is($services['alias_for_foo'], 'foo', '->load() parses aliases');
+$t->is($services['opt_args']->getArguments(), array(new sfServiceReference('bar'), new sfServiceReference('?bar')), '->getArguments() Required and optional service name');

--- a/test/unit/task/service/sfServicesGraphvizDumpTaskTest.php
+++ b/test/unit/task/service/sfServicesGraphvizDumpTaskTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the symfony package.
+ * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once(__DIR__.'/../../../bootstrap/task.php');
+
+$t = new lime_test(3);
+
+$dispatcher = new sfEventDispatcher();
+$formatter = new sfFormatter();
+
+$task = new sfGenerateProjectTask($dispatcher, $formatter);
+$task->run(array('test'));
+$task = new sfGenerateAppTask($dispatcher, $formatter);
+$task->run(array('frontend'));
+
+require_once sfConfig::get('sf_root_dir').'/config/ProjectConfiguration.class.php';
+$configuration = ProjectConfiguration::getApplicationConfiguration('frontend', 'test', true);
+
+$dumpDir = sfConfig::get('sf_cache_dir') . '/service-container';
+$dotFile = sprintf('%s/%d-graphviz.dot', $dumpDir, time());
+
+$t->ok(! is_file($dotFile), 'Graphviz not yet exists');
+
+$task = new sfServicesGraphvizDumpTask($dispatcher, $formatter);
+$t->is($task->run(), 0, 'sfServicesGraphvizDumpTask task returns a correct return code');
+
+if ($t->ok(is_file($dotFile), 'Graphviz created')) {
+  unlink($dotFile);
+}


### PR DESCRIPTION
Allows to declare services as non-required dependency in `services.yml` file.

This feature is also implemented in [Symfony 2](http://symfony.com/doc/current/book/service_container.html#ignoring-missing-dependencies).

Example:

``` yaml
services:
  opt_args:
    class: ClassOptionalArguments
    arguments: ['@?bar']
```

The `@bar` service is missing in service container, but the usage of `opt_args` service will not throw the `InvalidArgumentException`.

``` php
$optArgsService = $container->getService('opt_args');
// exception is not thrown
```
