### PR TITLE
Fix First translation access

### DIFF
--- a/lib/plugins/sfDoctrinePlugin/lib/record/sfDoctrineRecordI18nFilter.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/record/sfDoctrineRecordI18nFilter.class.php
@@ -51,7 +51,7 @@ class sfDoctrineRecordI18nFilter extends Doctrine_Record_Filter
   public function filterGet(Doctrine_Record $record, $name)
   {
     $culture = sfDoctrineRecord::getDefaultCulture();
-    if (isset($record['Translation'][$culture]) && '' != $record['Translation'][$culture][$name])
+    if ($record['Translation'] && isset($record['Translation'][$culture]) && '' != $record['Translation'][$culture][$name])
     {
       return $record['Translation'][$culture][$name];
     }


### PR DESCRIPTION
I ran into a problem where the first Translated field I tried to access would return in the DefaultCulture instead of the current culture because the $record['Translation'] was not set yet.
Testing $record['Translation'] first fixed it