### PR TITLE
Fix autoloading for locales with different lowercase rules

### DIFF
--- a/lib/autoload/sfCoreAutoload.class.php
+++ b/lib/autoload/sfCoreAutoload.class.php
@@ -116,7 +116,9 @@ class sfCoreAutoload
    */
   public function getClassPath($class)
   {
+    $old = setlocale(LC_ALL, 'C');
     $class = strtolower($class);
+    setlocale(LC_ALL, $old);
 
     if (!isset($this->classes[$class]))
     {
@@ -169,7 +171,9 @@ class sfCoreAutoload
           || false !== stripos($contents, 'interface '.$class)
           || false !== stripos($contents, 'trait '.$class))
       {
+        $old = setlocale(LC_ALL, 'C');
         $classes .= sprintf("    '%s' => '%s',\n", strtolower($class), substr(str_replace($libDir, '', $file), 1));
+        setlocale(LC_ALL, $old);
       }
     }
 


### PR DESCRIPTION
The class map generation and the lookup should use a neutral locale to
generate the lowercase classnames.
Without this fix locales like turkish will not be able to load classes
with an uppercase „I“ for example.