### PR TITLE
Fix `sfPatternRouting->getRoutes()` sometimes returning serialized routes

### DIFF
--- a/lib/routing/sfPatternRouting.class.php
+++ b/lib/routing/sfPatternRouting.class.php
@@ -151,6 +151,14 @@ class sfPatternRouting extends sfRouting
    */
   public function getRoutes()
   {
+    foreach ($this->routes as $name => $route) {
+      if (is_string($route)) {
+        $route = unserialize($route);
+        $route->setDefaultParameters($this->defaultParameters);
+        $this->routes[$name] = $route;
+      }
+    }
+
     return $this->routes;
   }
 


### PR DESCRIPTION
We have detected that in some cases this method was returning serialized entries instead of routing objects, this patch resolves the issue.