### PR TITLE
Add support for SameSite session cookies

### DIFF
--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -158,10 +158,11 @@ class sfWebResponse extends sfResponse
    * @param  string  $domain    Domain name
    * @param  bool    $secure    If secure
    * @param  bool    $httpOnly  If uses only HTTP
+   * @param  string  $samesite  SameSite cookies
    *
    * @throws <b>sfException</b> If fails to set the cookie
    */
-  public function setCookie($name, $value, $expire = null, $path = '/', $domain = '', $secure = false, $httpOnly = false)
+  public function setCookie($name, $value, $expire = null, $path = '/', $domain = '', $secure = false, $httpOnly = false, $samesite = '')
   {
     if ($expire !== null)
     {
@@ -187,6 +188,7 @@ class sfWebResponse extends sfResponse
       'domain'   => $domain,
       'secure'   => $secure ? true : false,
       'httpOnly' => $httpOnly,
+      'samesite' => $samesite
     );
   }
 
@@ -365,7 +367,18 @@ class sfWebResponse extends sfResponse
     // cookies
     foreach ($this->cookies as $cookie)
     {
-      setrawcookie($cookie['name'], $cookie['value'], $cookie['expire'], $cookie['path'], $cookie['domain'], $cookie['secure'], $cookie['httpOnly']);
+      if (PHP_VERSION_ID < 70300) {
+        setrawcookie($cookie['name'], $cookie['value'], $cookie['expire'], $cookie['path'], $cookie['domain'], $cookie['secure'], $cookie['httpOnly']);
+      } else {
+        setrawcookie($cookie['name'], $cookie['value'], array(
+          'expires'  => $cookie['expire'],
+          'path'     => $cookie['path'],
+          'domain'   => $cookie['domain'],
+          'secure'   => $cookie['secure'],
+          'httpOnly' => $cookie['httpOnly'],
+          'samesite' => $cookie['samesite'],
+        ));
+      }
 
       if ($this->options['logging'])
       {

--- a/lib/storage/sfSessionStorage.class.php
+++ b/lib/storage/sfSessionStorage.class.php
@@ -62,6 +62,7 @@ class sfSessionStorage extends sfStorage
       'session_cookie_domain'   => $cookieDefaults['domain'],
       'session_cookie_secure'   => $cookieDefaults['secure'],
       'session_cookie_httponly' => isset($cookieDefaults['httponly']) ? $cookieDefaults['httponly'] : false,
+      'session_cookie_samesite' => isset($cookieDefaults['samesite']) ? $cookieDefaults['samesite'] : '',
       'session_cache_limiter'   => null,
     ), $options);
 
@@ -83,7 +84,19 @@ class sfSessionStorage extends sfStorage
     $domain   = $this->options['session_cookie_domain'];
     $secure   = $this->options['session_cookie_secure'];
     $httpOnly = $this->options['session_cookie_httponly'];
-    session_set_cookie_params($lifetime, $path, $domain, $secure, $httpOnly);
+    $samesite = $this->options['session_cookie_samesite'];
+    if (PHP_VERSION_ID < 70300) {
+      session_set_cookie_params($lifetime, $path, $domain, $secure, $httpOnly);
+    } else {
+      session_set_cookie_params(array(
+        'lifetime' => $lifetime,
+        'path'     => $path,
+        'domain'   => $domain,
+        'secure'   => $secure,
+        'httponly' => $httpOnly,
+        'samesite' => $samesite
+      ));
+    }
 
     if (null !== $this->options['session_cache_limiter'])
     {

--- a/test/unit/response/sfWebResponseTest.php
+++ b/test/unit/response/sfWebResponseTest.php
@@ -288,7 +288,7 @@ $t->is($response->clearJavascripts(), array(), '->clearJavascripts() removes all
 // ->setCookie() ->getCookies()
 $t->diag('->setCookie() ->getCookies()');
 $response->setCookie('foo', 'bar');
-$t->is($response->getCookies(), array('foo' => array('name' => 'foo', 'value' => 'bar', 'expire' => null, 'path' => '/', 'domain' => '', 'secure' => false, 'httpOnly' => false)), '->setCookie() adds a cookie for the response');
+$t->is($response->getCookies(), array('foo' => array('name' => 'foo', 'value' => 'bar', 'expire' => null, 'path' => '/', 'domain' => '', 'secure' => false, 'httpOnly' => false, 'samesite' => '')), '->setCookie() adds a cookie for the response');
 
 // ->setHeaderOnly() ->getHeaderOnly()
 $t->diag('->setHeaderOnly() ->isHeaderOnly()');


### PR DESCRIPTION
Starting from PHP 7.3 there's native support for [SameSite cookies](https://web.dev/samesite-cookies-explained/) ([RFC6265bis](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02)) which requires using a new session_get_cookie_params() parameter syntax.