### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: php
 
 php:
-    - 5.5
-    - 5.6
     - 7.0
     - 7.1
     - 7.2
     - nightly
+
+dist: trusty
 
 # run build against nightly but allow them to fail
 matrix:
@@ -16,13 +16,12 @@ matrix:
     include:
         - php: 5.3
           dist: precise
-          sudo: required
         - php: 5.4
           dist: precise
-          sudo: required
-
-# faster builds on new travis setup not using sudo
-sudo: false
+        - php: 5.5
+          dist: trusty
+        - php: 5.6
+          dist: trusty
 
 services:
     - memcached

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
     - 7.2
     - nightly
 
-dist: trusty
+dist: xenial
 
 # run build against nightly but allow them to fail
 matrix:


### PR DESCRIPTION
- running PHP 5.5 and 5.6 with Trusty makes it work again;
- removed unused travis key 'sudo';