### PR TITLE
Backport fix for cve-2019-18888

### DIFF
--- a/lib/validator/sfValidatorFile.class.php
+++ b/lib/validator/sfValidatorFile.class.php
@@ -263,7 +263,7 @@ class sfValidatorFile extends sfValidatorBase
   {
     ob_start();
     //need to use --mime instead of -i. see #6641
-    $cmd = 'file -b --mime %s -- 2>/dev/null';
+    $cmd = 'file -b --mime -- %s 2>/dev/null';
     $file = (0 === strpos($file, '-') ? './' : '').$file;
     passthru(sprintf($cmd, escapeshellarg($file)), $return);
     if ($return > 0)

--- a/lib/validator/sfValidatorFile.class.php
+++ b/lib/validator/sfValidatorFile.class.php
@@ -263,7 +263,9 @@ class sfValidatorFile extends sfValidatorBase
   {
     ob_start();
     //need to use --mime instead of -i. see #6641
-    passthru(sprintf('file -b --mime %s 2>/dev/null', escapeshellarg($file)), $return);
+    $cmd = 'file -b --mime %s -- 2>/dev/null';
+    $file = (0 === strpos($file, '-') ? './' : '').$file;
+    passthru(sprintf($cmd, escapeshellarg($file)), $return);
     if ($return > 0)
     {
       ob_end_clean();

--- a/test/unit/validator/sfValidatorFileTest.php
+++ b/test/unit/validator/sfValidatorFileTest.php
@@ -106,6 +106,7 @@ $v = new testValidatorFile();
 $t->is($v->guessFromFileBinary($tmpDir.'/test.txt'), 'text/plain', '->guessFromFileBinary() guesses the type of a given file');
 $t->is($v->guessFromFileBinary($tmpDir.'/foo.txt'), null, '->guessFromFileBinary() returns null if the file type is not guessable');
 $t->is($v->guessFromFileBinary('/bin/ls'), (PHP_OS != 'Darwin') ? 'application/x-executable' : 'application/octet-stream', '->guessFromFileBinary() returns correct type if file is guessable');
+$t->is($v->guessFromFileBinary('-test'), null, '->guessFromFileBinary() returns null if file path has leading dash');
 
 // ->getMimeType()
 $t->diag('->getMimeType()');


### PR DESCRIPTION
`guessFromFileBinary` may also be impacted by [cve-2019-18888](https://symfony.com/blog/cve-2019-18888-prevent-argument-injection-in-a-mimetypeguesser) where
the provided file paths were not being properly escaped before being used.

This PR backports the fix from commit https://github.com/symfony/symfony/commit/691486e43ce0e4893cd703e221bafc10a871f365 to make sure the issue is not exploitable.