### PR TITLE
Test PHP 7.3 and 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
@@ -21,6 +20,9 @@ matrix:
           sudo: required
         - php: 5.4
           dist: precise
+          sudo: required
+        - php: 5.5
+          dist: trusty
           sudo: required
 
 # faster builds on new travis setup not using sudo

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
+    - 7.4
     - nightly
 
 # run build against nightly but allow them to fail

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.6
     - 7.0
     - 7.1
     - 7.2
@@ -22,6 +21,9 @@ matrix:
           dist: precise
           sudo: required
         - php: 5.5
+          dist: trusty
+          sudo: required
+        - php: 5.6
           dist: trusty
           sudo: required
 

--- a/lib/i18n/sfDateFormat.class.php
+++ b/lib/i18n/sfDateFormat.class.php
@@ -229,7 +229,7 @@ class sfDateFormat
     for ($i = 0, $max = count($tokens); $i < $max; $i++)
     {
       $pattern = $tokens[$i];
-      if ($pattern{0} == "'" && $pattern{strlen($pattern) - 1} == "'")
+      if ($pattern[0] == "'" && $pattern{strlen($pattern) - 1} == "'")
       {
         $tokens[$i] = str_replace('``````', '\'', preg_replace('/(^\')|(\'$)/', '', $pattern));
       }
@@ -266,9 +266,9 @@ class sfDateFormat
    */
   protected function getFunctionName($token)
   {
-    if (isset($this->tokens[$token{0}]))
+    if (isset($this->tokens[$token[0]]))
     {
-      return $this->tokens[$token{0}];
+      return $this->tokens[$token[0]];
     }
   }
 

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -75,7 +75,14 @@ class sfWebRequest extends sfRequest
     parent::initialize($dispatcher, $parameters, $attributes, $options);
 
     // GET parameters
-    $this->getParameters = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($_GET) : $_GET;
+    if (version_compare(PHP_VERSION, '5.4', '<') && get_magic_quotes_gpc())
+    {
+      $this->getParameters = sfToolkit::stripslashesDeep($_GET);
+    }
+    else
+    {
+      $this->getParameters = $_GET;
+    }
     $this->parameterHolder->add($this->getParameters);
 
     $postParameters = $_POST;
@@ -148,7 +155,15 @@ class sfWebRequest extends sfRequest
       $this->setMethod(self::GET);
     }
 
-    $this->postParameters = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($postParameters) : $postParameters;
+    if (version_compare(PHP_VERSION, '5.4', '<') && get_magic_quotes_gpc())
+    {
+      $this->postParameters = sfToolkit::stripslashesDeep($postParameters);
+    }
+    else
+    {
+      $this->postParameters = $postParameters;
+    }
+
     $this->parameterHolder->add($this->postParameters);
 
     if ($formats = $this->getOption('formats'))
@@ -600,7 +615,14 @@ class sfWebRequest extends sfRequest
 
     if (isset($_COOKIE[$name]))
     {
-      $retval = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($_COOKIE[$name]) : $_COOKIE[$name];
+      if (version_compare(PHP_VERSION, '5.4', '<') && get_magic_quotes_gpc())
+      {
+        $retval = sfToolkit::stripslashesDeep($_COOKIE[$name]);
+      }
+      else
+      {
+        $retval = $_COOKIE[$name];
+      }
     }
 
     return $retval;

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -75,7 +75,7 @@ class sfWebRequest extends sfRequest
     parent::initialize($dispatcher, $parameters, $attributes, $options);
 
     // GET parameters
-    if (version_compare(PHP_VERSION, '5.4', '<') && get_magic_quotes_gpc())
+    if (version_compare(PHP_VERSION, '5.4.0-dev', '<') && get_magic_quotes_gpc())
     {
       $this->getParameters = sfToolkit::stripslashesDeep($_GET);
     }
@@ -155,7 +155,7 @@ class sfWebRequest extends sfRequest
       $this->setMethod(self::GET);
     }
 
-    if (version_compare(PHP_VERSION, '5.4', '<') && get_magic_quotes_gpc())
+    if (version_compare(PHP_VERSION, '5.4.0-dev', '<') && get_magic_quotes_gpc())
     {
       $this->postParameters = sfToolkit::stripslashesDeep($postParameters);
     }
@@ -615,7 +615,7 @@ class sfWebRequest extends sfRequest
 
     if (isset($_COOKIE[$name]))
     {
-      if (version_compare(PHP_VERSION, '5.4', '<') && get_magic_quotes_gpc())
+      if (version_compare(PHP_VERSION, '5.4.0-dev', '<') && get_magic_quotes_gpc())
       {
         $retval = sfToolkit::stripslashesDeep($_COOKIE[$name]);
       }

--- a/lib/util/sfFinder.class.php
+++ b/lib/util/sfFinder.class.php
@@ -580,10 +580,10 @@ class sfFinder
 
   public static function isPathAbsolute($path)
   {
-    if ($path{0} === '/' || $path{0} === '\\' ||
-        (strlen($path) > 3 && ctype_alpha($path{0}) &&
-         $path{1} === ':' &&
-         ($path{2} === '\\' || $path{2} === '/')
+    if ($path[0] === '/' || $path[0] === '\\' ||
+        (strlen($path) > 3 && ctype_alpha($path[0]) &&
+         $path[1] === ':' &&
+         ($path[2] === '\\' || $path[2] === '/')
         )
        )
     {


### PR DESCRIPTION
* Test with PHP 7.3 and 7.4
* Fix array and string offset access using curly braces (deprecated since PHP 7.4 - see https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace)
* Call [`get_magic_quotes_gpc()`](https://www.php.net/manual/en/function.get-magic-quotes-gpc.php) only for PHP < 5.4. It always returned false since PHP 5.4 and is deprecated since PHP 7.4
* Fix Travis config for PHP 5.5 and 5.6