### PR TITLE
Fix php 7.4 "Trying to access array offset on value of type null" notice on isCSRFProtected()

### DIFF
--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -944,7 +944,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    */
   public function isCSRFProtected()
   {
-    return null !== $this->validatorSchema[self::$CSRFFieldName];
+    return isset($this->validatorSchema) && null !== $this->validatorSchema[self::$CSRFFieldName];
   }
 
   /**


### PR DESCRIPTION
I was having the "Trying to access array offset on value of type null" notice on this line in some pages of my website when using php 7.4. This should fix it