### PR TITLE
Php 7.4 Incompatibility Fixes

### DIFF
--- a/lib/helper/UrlHelper.php
+++ b/lib/helper/UrlHelper.php
@@ -630,7 +630,7 @@ function _encodeText($text)
 
   for ($i = 0; $i < strlen($text); $i++)
   {
-    $char = $text{$i};
+    $char = $text[$i];
     $r = mt_rand(0, 100);
 
     # roughly 10% raw, 45% hex, 45% dec

--- a/lib/i18n/sfDateFormat.class.php
+++ b/lib/i18n/sfDateFormat.class.php
@@ -229,7 +229,7 @@ class sfDateFormat
     for ($i = 0, $max = count($tokens); $i < $max; $i++)
     {
       $pattern = $tokens[$i];
-      if ($pattern[0] == "'" && $pattern[(strlen($pattern) - 1)] == "'")
+      if ($pattern[0] == "'" && $pattern[strlen($pattern) - 1] == "'")
       {
         $tokens[$i] = str_replace('``````', '\'', preg_replace('/(^\')|(\'$)/', '', $pattern));
       }

--- a/lib/i18n/sfDateFormat.class.php
+++ b/lib/i18n/sfDateFormat.class.php
@@ -229,7 +229,7 @@ class sfDateFormat
     for ($i = 0, $max = count($tokens); $i < $max; $i++)
     {
       $pattern = $tokens[$i];
-      if ($pattern[0] == "'" && $pattern{strlen($pattern) - 1} == "'")
+      if ($pattern[0] == "'" && $pattern[(strlen($pattern) - 1)] == "'")
       {
         $tokens[$i] = str_replace('``````', '\'', preg_replace('/(^\')|(\'$)/', '', $pattern));
       }
@@ -397,30 +397,30 @@ class sfDateFormat
 
     for ($i = 0, $max = strlen($pattern); $i < $max; $i++)
     {
-      if ($char == null || $pattern{$i} == $char || $text)
+      if ($char == null || $pattern[$i] == $char || $text)
       {
-        $token .= $pattern{$i};
+        $token .= $pattern[$i];
       }
       else
       {
         $tokens[] = str_replace("''", "'", $token);
-        $token = $pattern{$i};
+        $token = $pattern[$i];
       }
 
-      if ($pattern{$i} == "'" && $text == false)
+      if ($pattern[$i] == "'" && $text == false)
       {
         $text = true;
       }
-      else if ($text && $pattern{$i} == "'" && $char == "'")
+      else if ($text && $pattern[$i] == "'" && $char == "'")
       {
         $text = true;
       }
-      else if ($text && $char != "'" && $pattern{$i} == "'")
+      else if ($text && $char != "'" && $pattern[$i] == "'")
       {
         $text = false;
       }
 
-      $char = $pattern{$i};
+      $char = $pattern[$i];
 
     }
     $tokens[] = $token;

--- a/lib/i18n/sfNumberFormat.class.php
+++ b/lib/i18n/sfNumberFormat.class.php
@@ -193,7 +193,7 @@ class sfNumberFormat
       // now for the integer groupings
       for ($i = 0; $i < $len; $i++)
       {
-        $char = $string{$len - $i - 1};
+        $char = $string[($len - $i - 1)];
 
         if ($multiGroup && $count == 0)
         {

--- a/lib/i18n/sfNumberFormat.class.php
+++ b/lib/i18n/sfNumberFormat.class.php
@@ -193,7 +193,7 @@ class sfNumberFormat
       // now for the integer groupings
       for ($i = 0; $i < $len; $i++)
       {
-        $char = $string[($len - $i - 1)];
+        $char = $string[$len - $i - 1];
 
         if ($multiGroup && $count == 0)
         {

--- a/lib/i18n/sfNumberFormatInfo.class.php
+++ b/lib/i18n/sfNumberFormatInfo.class.php
@@ -316,7 +316,7 @@ class sfNumberFormatInfo
         // to find the groupsize 1.
         for ($i = strlen($pattern) - 1; $i >= 0; $i--)
         {
-          if ($pattern{$i} == $digit || $pattern{$i} == $hash)
+          if ($pattern[$i] == $digit || $pattern[$i] == $hash)
           {
             $groupSize1 = $i - $groupPos1;
             break;
@@ -335,11 +335,11 @@ class sfNumberFormatInfo
     {
       for ($i = strlen($pattern) - 1; $i >= 0; $i--)
       {
-        if ($pattern{$i} == $dot)
+        if ($pattern[$i] == $dot)
         {
           break;
         }
-        if ($pattern{$i} == $digit)
+        if ($pattern[$i] == $digit)
         {
           $decimalPoints = $i - $decimalPos;
           break;

--- a/lib/view/sfViewCacheManager.class.php
+++ b/lib/view/sfViewCacheManager.class.php
@@ -236,7 +236,7 @@ class sfViewCacheManager
       {
         $varys[] = $header . '-' . preg_replace('/\W+/', '_', $request->getHttpHeader($header));
       }
-      $vary = implode($varys, '-');
+      $vary = implode('-', $varys);
     }
 
     return $vary;


### PR DESCRIPTION
1) Passing the $glue and $pieces parameters in reverse order to implode has been deprecated since PHP 7.4; $glue should be the first parameter and $pieces the second
2) Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4