### PR TITLE
Fix for `Warning: ini_set(): A session is active...`

### DIFF
--- a/lib/config/sfFactoryConfigHandler.class.php
+++ b/lib/config/sfFactoryConfigHandler.class.php
@@ -109,6 +109,10 @@ class sfFactoryConfigHandler extends sfYamlConfigHandler
             unset($parameters['database']);
           }
 
+          if (isset($config['user']['param']['timeout'])) {
+            $defaultParameters[] = sprintf("'gc_maxlifetime' => %d,", $config['user']['param']['timeout']);
+          }
+
           $instances[] = sprintf("  \$class = sfConfig::get('sf_factory_storage', '%s');\n  \$this->factories['storage'] = new \$class(array_merge(array(\n%s\n), sfConfig::get('sf_factory_storage_parameters', %s)));", $class, implode("\n", $defaultParameters), var_export($parameters, true));
           break;
 

--- a/lib/storage/sfSessionStorage.class.php
+++ b/lib/storage/sfSessionStorage.class.php
@@ -63,6 +63,7 @@ class sfSessionStorage extends sfStorage
       'session_cookie_secure'   => $cookieDefaults['secure'],
       'session_cookie_httponly' => isset($cookieDefaults['httponly']) ? $cookieDefaults['httponly'] : false,
       'session_cache_limiter'   => null,
+      'gc_maxlifetime'          => 1800,
     ), $options);
 
     // initialize parent
@@ -88,6 +89,12 @@ class sfSessionStorage extends sfStorage
     if (null !== $this->options['session_cache_limiter'])
     {
       session_cache_limiter($this->options['session_cache_limiter']);
+    }
+
+    // force the max lifetime for session garbage collector to be greater than timeout
+    if (ini_get('session.gc_maxlifetime') < $this->options['gc_maxlifetime'])
+    {
+      ini_set('session.gc_maxlifetime', $this->options['gc_maxlifetime']);
     }
 
     if ($this->options['auto_start'] && !self::$sessionStarted)

--- a/lib/user/sfBasicSecurityUser.class.php
+++ b/lib/user/sfBasicSecurityUser.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -42,7 +42,7 @@ class sfBasicSecurityUser extends sfUser implements sfSecurityUser
 
   /**
    * Returns the current user's credentials.
-   * 
+   *
    * @return array
    */
   public function getCredentials()
@@ -249,12 +249,6 @@ class sfBasicSecurityUser extends sfUser implements sfSecurityUser
     if (!array_key_exists('timeout', $this->options))
     {
       $this->options['timeout'] = 1800;
-    }
-
-    // force the max lifetime for session garbage collector to be greater than timeout
-    if (ini_get('session.gc_maxlifetime') < $this->options['timeout'])
-    {
-      ini_set('session.gc_maxlifetime', $this->options['timeout']);
     }
 
     // read data from storage


### PR DESCRIPTION
Addresses the issue: https://github.com/FriendsOfSymfony1/symfony1/issues/183

Changing session settings shouldn't be done on `sfBasicSecurityUser` class. Instead it should be done near (and **_before_**) the call to `session_start()` in `sfSessionStorage`