### PR TITLE
Remove notice appeared on php 7.4

### DIFF
--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -63,7 +63,6 @@ class sfForm implements ArrayAccess, Iterator, Countable
    */
   public function __construct($defaults = array(), $options = array(), $CSRFSecret = null)
   {
-    $this->setDefaults($defaults);
     $this->options = $options;
     $this->localCSRFSecret = $CSRFSecret;
 
@@ -71,6 +70,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
     $this->widgetSchema    = new sfWidgetFormSchema();
     $this->errorSchema     = new sfValidatorErrorSchema($this->validatorSchema);
 
+    $this->setDefaults($defaults);
     $this->setup();
     $this->configure();
 


### PR DESCRIPTION
PHP Notice: Trying to access array offset on value of type null in sfForm.class.php on line 947`