### PR TITLE
[Lime] Fix backward compatibility break for handle_exception signature

### DIFF
--- a/lib/vendor/lime/lime.php
+++ b/lib/vendor/lime/lime.php
@@ -587,7 +587,14 @@ class lime_test
     $this->error($type.': '.$message, $file, $line, $trace);
   }
 
-  public function handle_exception(Throwable $exception)
+  /**
+   * Handles exception.
+   *
+   * @param Exception|Throwable $exception
+   *
+   * @return bool
+   */
+  public function handle_exception($exception)
   {
     $this->error(get_class($exception).': '.$exception->getMessage(), $exception->getFile(), $exception->getLine(), $exception->getTrace());
 


### PR DESCRIPTION
Throwables were introduced since PHP 7.
http://php.net/manual/en/class.throwable.php

Now `lime_test::handle_exception()` method works properly with any `Exception` and `Error` instances.

This fix the backward compatibility breaking changes introduce on:

5ea8d656 exception_handler signature changed in php7