### PR TITLE
Updated lexpress to fos1 in the submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	branch = 5.x
 [submodule "lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine"]
 	path = lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine
-	url = https://github.com/LExpress/doctrine1.git
+	url = https://github.com/FriendsOfSymfony1/doctrine1.git


### PR DESCRIPTION
During my tests with submodules and swiftmailer I've seen the old link to lexpress.