### PR TITLE
Feature/display errors to stderr

### DIFF
--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -165,7 +165,8 @@ This allow you to remove all stylesheets and/or all javascripts added into the g
 Configuration
 -------------
 
-A new configuration `sf_upload_dir_name` contains 'uploads' has been added.
+* A new configuration `sf_upload_dir_name` contains 'uploads' has been added.
+* A new settings `sf_display_errors` has been added to change display_errors from stdout to stderr for example.
 
 Performance
 -----------

--- a/lib/config/sfApplicationConfiguration.class.php
+++ b/lib/config/sfApplicationConfiguration.class.php
@@ -143,7 +143,8 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
     }
 
     // error settings
-    ini_set('display_errors', $this->isDebug() ? 'on' : 'off');
+    // PHP >= 5.2.4 supports stdout/stderr instead of bool here: https://www.php.net/manual/en/errorfunc.configuration.php#ini.display-errors
+    ini_set('display_errors', $this->isDebug() ? sfConfig::get('sf_display_errors', 'stdout') : '');
     error_reporting(sfConfig::get('sf_error_reporting'));
 
     // initialize plugin configuration objects


### PR DESCRIPTION
This pr allows to set stderr as the target for display_errors. For us it is helpful during development, especially while upgrading to newer versions of PHP. The default (stdout) is equal to "On" which is deprecated since 5.2.4: https://www.php.net/manual/en/errorfunc.configuration.php#ini.display-errors