### PR TITLE
Add consistent local environment for testing with docker and docker-compose

### DIFF
--- a/.docker/php53/Dockerfile
+++ b/.docker/php53/Dockerfile
@@ -1,0 +1,57 @@
+FROM buildpack-deps:jessie
+
+ENV PHP_VERSION 5.3.29
+
+# php 5.3 needs older autoconf
+RUN set -eux; \
+  \
+  apt-get update; \
+  apt-get install -y \
+    curl \
+    autoconf2.13 \
+  ; \
+  rm -r /var/lib/apt/lists/*; \
+  \
+  curl -sSLfO http://launchpadlibrarian.net/140087283/libbison-dev_2.7.1.dfsg-1_amd64.deb; \
+  curl -sSLfO http://launchpadlibrarian.net/140087282/bison_2.7.1.dfsg-1_amd64.deb; \
+  dpkg -i libbison-dev_2.7.1.dfsg-1_amd64.deb; \
+  dpkg -i bison_2.7.1.dfsg-1_amd64.deb; \
+  rm *.deb; \
+  \
+  curl -sSLf "https://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2; \
+  echo 'c4e1cf6972b2a9c7f2777a18497d83bf713cdbecabb65d3ff62ba441aebb0091  php.tar.bz2' | sha256sum -cw --status; \
+  \
+  mkdir -p /usr/src/php; \
+  tar -xf php.tar.bz2 -C /usr/src/php --strip-components=1; \
+  rm php.tar.bz2*; \
+  \
+  cd /usr/src/php; \
+  ./buildconf --force; \
+  ./configure --disable-cgi \
+    $(command -v apxs2 > /dev/null 2>&1 && echo '--with-apxs2' || true) \
+    --with-pdo-mysql \
+    --with-zlib \
+    --enable-mbstring \
+  ; \
+  make -j"$(nproc)"; \
+  make install; \
+  \
+  dpkg -r \
+    bison \
+    libbison-dev \
+  ; \
+  apt-get purge -y --auto-remove \
+    autoconf2.13 \
+  ; \
+  rm -r /usr/src/php
+
+# Install APC PHP extension
+#
+RUN set -eux; \
+  \
+  pecl install apc-3.1.13; \
+  echo 'extension=apc.so' >> /usr/local/lib/php.ini; \
+  \
+  rm -r /tmp/pear;
+
+CMD ["php", "-a"]

--- a/.docker/php54/Dockerfile
+++ b/.docker/php54/Dockerfile
@@ -1,0 +1,34 @@
+FROM php:5.4-cli
+
+RUN docker-php-ext-install pdo
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install mbstring
+
+# Install APC PHP extension
+#
+RUN set -eux; \
+  pecl install apc-3.1.13; \
+  docker-php-ext-enable apc; \
+  rm -r /tmp/pear;
+
+# Install memcache PHP extension
+#
+ARG MEMCACHE_VERSION
+RUN set -eux; \
+  buildDeps=' \
+    libzip-dev \
+  '; \
+  apt-get update; \
+  apt-get install -y --no-upgrade --no-install-recommends \
+    $buildDeps \
+  ; \
+  \
+  pecl install memcache-${MEMCACHE_VERSION}; \
+  docker-php-ext-enable memcache; \
+  \
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=true \
+    $buildDeps \
+  ; \
+  apt-get clean; \
+  rm -rf /var/lib/apt/lists/*; \
+  rm -r /tmp/pear

--- a/.docker/php55_71/Dockerfile
+++ b/.docker/php55_71/Dockerfile
@@ -1,0 +1,40 @@
+ARG PHP_TAG
+FROM php:${PHP_TAG}
+
+RUN docker-php-ext-install pdo
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install mbstring
+
+# Install APCu PHP extension
+#
+ARG APCU_VERSION
+RUN set -eux; \
+  \
+  test x"" = x"${APCU_VERSION}" || { \
+    pecl install apcu-${APCU_VERSION}; \
+    docker-php-ext-enable apcu; \
+    \
+    rm -r /tmp/pear; \
+  }
+
+# Install memcache PHP extension
+#
+ARG MEMCACHE_VERSION
+RUN set -eux; \
+  buildDeps=' \
+    libzip-dev \
+  '; \
+  apt-get update; \
+  apt-get install -y --no-upgrade --no-install-recommends \
+    $buildDeps \
+  ; \
+  \
+  pecl install memcache-${MEMCACHE_VERSION}; \
+  docker-php-ext-enable memcache; \
+  \
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=true \
+    $buildDeps \
+  ; \
+  apt-get clean; \
+  rm -rf /var/lib/apt/lists/*; \
+  rm -r /tmp/pear

--- a/.docker/php72_73/Dockerfile
+++ b/.docker/php72_73/Dockerfile
@@ -1,0 +1,56 @@
+ARG PHP_VERSION
+FROM php:${PHP_VERSION}-cli
+
+RUN docker-php-ext-install pdo
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install mbstring
+
+# Install APCu PHP extension
+#
+ARG APCU_VERSION
+RUN set -eux; \
+  \
+  test x"" = x"${APCU_VERSION}" || { \
+    pecl install apcu-${APCU_VERSION}; \
+    docker-php-ext-enable apcu; \
+    \
+    rm -r /tmp/pear; \
+  }
+
+# Install memcache PHP extension
+#
+ARG MEMCACHE_VERSION
+RUN set -eux; \
+  buildDeps=' \
+    libzip-dev \
+  '; \
+  apt-get update; \
+  apt-get install -y --no-upgrade --no-install-recommends \
+    $buildDeps \
+  ; \
+  \
+  pecl install memcache-${MEMCACHE_VERSION}; \
+  docker-php-ext-enable memcache; \
+  \
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=true \
+    $buildDeps \
+  ; \
+  apt-get clean; \
+  rm -rf /var/lib/apt/lists/*; \
+  rm -r /tmp/pear
+
+# For consistent mime type file guesser
+RUN set -eux; \
+  distFilePath=`which file`; \
+  \
+  mv ${distFilePath} ${distFilePath}.dist; \
+  { \
+    echo '#! /bin/sh -eu'; \
+    echo ''; \
+    echo "${distFilePath}"'.dist "$@" | sed -e s,application/x-pie-executable,application/x-executable,g'; \
+  } | tee ${distFilePath}; \
+  \
+  chmod +x ${distFilePath}; \
+  \
+  file /bin/ls --mime | grep application/x-executable; \
+  :;

--- a/.docker/php74_81/Dockerfile
+++ b/.docker/php74_81/Dockerfile
@@ -1,0 +1,68 @@
+ARG PHP_VERSION
+FROM php:${PHP_VERSION}-cli
+
+RUN docker-php-ext-install pdo
+RUN docker-php-ext-install pdo_mysql
+
+# Install mbstring PHP extension
+#
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y --no-upgrade --no-install-recommends \
+    libonig-dev \
+  ; \
+  \
+  apt-get clean; \
+  rm -rf /var/lib/apt/lists/*; \
+  \
+  docker-php-ext-install mbstring
+
+# Install APCu PHP extension
+#
+ARG APCU_VERSION
+RUN set -eux; \
+  \
+  test x"" = x"${APCU_VERSION}" || { \
+    pecl install apcu-${APCU_VERSION}; \
+    docker-php-ext-enable apcu; \
+    \
+    rm -r /tmp/pear; \
+  }
+
+# Install memcache PHP extension
+#
+ARG MEMCACHE_VERSION
+RUN set -eux; \
+  buildDeps=' \
+    libzip-dev \
+  '; \
+  apt-get update; \
+  apt-get install -y --no-upgrade --no-install-recommends \
+    $buildDeps \
+  ; \
+  \
+  pecl install memcache-${MEMCACHE_VERSION}; \
+  docker-php-ext-enable memcache; \
+  \
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=true \
+    $buildDeps \
+  ; \
+  apt-get clean; \
+  rm -rf /var/lib/apt/lists/*; \
+  rm -r /tmp/pear
+
+# For consistent mime type file guesser
+RUN set -eux; \
+  distFilePath=`which file`; \
+  \
+  mv ${distFilePath} ${distFilePath}.dist; \
+  { \
+    echo '#! /bin/sh -eu'; \
+    echo ''; \
+    echo "${distFilePath}"'.dist "$@" | sed -e s,application/x-pie-executable,application/x-executable,g'; \
+  } | tee ${distFilePath}; \
+  \
+  chmod +x ${distFilePath}; \
+  \
+  file /bin/ls --mime | grep application/x-executable; \
+  :;

--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,11 @@
+#
+# Environment variables used by docker-compose for test.
+#
+# Copy to `.env` in order to use it.
+#
+
+# APC test are disabled.
+#
+# To enable them in order to provide a fix, set to "on".
+#
+APC_ENABLE_CLI=off

--- a/README.md
+++ b/README.md
@@ -54,6 +54,37 @@ Option 2: Using Git submodules:
     git submodule add https://github.com/FriendsOfSymfony1/symfony1.git lib/vendor/symfony
     git submodule update --init --recursive
 
+
+Tests
+-----
+
+### Prerequisites
+
+  * docker-engine version 17.12.0+
+  * docker-compose version 1.20.0+
+
+### How to execute all tests on all supported PHP versions and dependencies?
+
+    test/bin/test
+
+### For PHP 7.3 and for lowest dependencies versions?
+
+    test/bin/test php73 lowest
+
+### For PHP 7.3 and for highest dependencies versions?
+
+    test/bin/test php73 highest
+
+### For executing a dedicated test file?
+
+    test/bin/test php73 highest test/unit/cache/sfAPCCacheTest.php
+
+
+### When you finish your work day, do not forget to clean up your desk
+
+    docker-compose down
+
+
 Documentation
 -------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,176 @@
+version: '3.5'
+
+volumes:
+  db_socket:
+
+services:
+  composer:
+    image: composer
+    working_dir: /app
+    volumes:
+      - .:/app
+    entrypoint:
+      - sh
+      - -c
+      - |
+        exec tail -f /dev/null
+
+  php53:
+    build: .docker/php53
+    working_dir: /app
+    volumes:
+      - .:/app
+      - db_socket:/var/run/mysqld
+    entrypoint:
+      - sh
+      - -c
+      - |
+        {
+          echo 'pdo_mysql.default_socket = /var/run/mysqld/mysql.sock'
+          echo 'memory_limit = -1'
+          echo 'short_open_tag = off'
+          echo 'magic_quotes_gpc = off'
+          echo 'date.timezone = "UTC"'
+          echo 'apc.enable_cli = ${APC_ENABLE_CLI-off}'
+          echo 'apc.use_request_time = 0'
+        } | tee -a /usr/local/lib/php.ini
+
+        exec tail -f /dev/null
+    depends_on:
+      - db
+
+  php54: &services_php54
+    build:
+      context: .docker/php54
+      args:
+        MEMCACHE_VERSION: '3.0.8'
+    environment:
+      MEMCACHED_HOST: memcached
+    working_dir: /app
+    volumes:
+      - .:/app
+      - db_socket:/var/run/mysqld
+    entrypoint:
+      - sh
+      - -c
+      - |
+        {
+          echo 'pdo_mysql.default_socket = /var/run/mysqld/mysql.sock'
+          echo 'memory_limit = -1'
+          echo 'short_open_tag = off'
+          echo 'magic_quotes_gpc = off'
+          echo 'date.timezone = "UTC"'
+          echo 'apc.enable_cli = ${APC_ENABLE_CLI-off}'
+          echo 'apc.use_request_time = 0'
+        } | tee -a /usr/local/etc/php/php.ini
+
+        exec tail -f /dev/null
+    depends_on:
+      - db
+      - memcached
+
+  php55:
+    <<: *services_php54
+    build:
+      context: .docker/php55_71
+      args:
+        PHP_TAG: '5.5-cli'
+        MEMCACHE_VERSION: '3.0.8'
+        APCU_VERSION: '4.0.11'
+
+  php56:
+    <<: *services_php54
+    build:
+      context: .docker/php55_71
+      args:
+        PHP_TAG: '5.6-cli-jessie'
+        MEMCACHE_VERSION: '3.0.8'
+        APCU_VERSION: '4.0.11'
+
+  php70:
+    <<: *services_php54
+    build:
+      context: .docker/php55_71
+      args:
+        PHP_TAG: '7.0-cli-jessie'
+        MEMCACHE_VERSION: '4.0.5.2'
+        APCU_VERSION: ''
+
+  php71:
+    <<: *services_php54
+    build:
+      context: .docker/php55_71
+      args:
+        PHP_TAG: '7.1-cli-jessie'
+        MEMCACHE_VERSION: '4.0.5.2'
+        APCU_VERSION: ''
+
+
+  php72:
+    <<: *services_php54
+    build:
+      context: .docker/php72_73
+      args:
+        PHP_VERSION: '7.2'
+        MEMCACHE_VERSION: '4.0.5.2'
+        APCU_VERSION: ''
+
+
+  php73:
+    <<: *services_php54
+    build:
+      context: .docker/php72_73
+      args:
+        PHP_VERSION: '7.3'
+        MEMCACHE_VERSION: '4.0.5.2'
+        APCU_VERSION: ''
+
+
+  php74:
+    <<: *services_php54
+    build:
+      context: .docker/php74_81
+      args:
+        PHP_VERSION: '7.4'
+        MEMCACHE_VERSION: '4.0.5.2'
+        APCU_VERSION: ''
+
+
+  php80:
+    <<: *services_php54
+    build:
+      context: .docker/php74_81
+      args:
+        PHP_VERSION: '8.0'
+        MEMCACHE_VERSION: '8.0'
+        APCU_VERSION: ''
+
+
+  php81:
+    <<: *services_php54
+    build:
+      context: .docker/php74_81
+      args:
+        PHP_VERSION: '8.1'
+        MEMCACHE_VERSION: '8.0'
+        APCU_VERSION: ''
+
+
+  db:
+    image: mysql:5.5.62
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - db_socket:/tmp
+    entrypoint:
+      - bash
+      - -c
+      - |
+        {
+            echo "CREATE DATABASE IF NOT EXISTS test;"
+        } | tee /docker-entrypoint-initdb.d/init.sql
+
+        exec /usr/local/bin/docker-entrypoint.sh mysqld
+
+  memcached:
+    image: memcached:1.6.13-alpine3.15

--- a/test/bin/test
+++ b/test/bin/test
@@ -1,0 +1,89 @@
+#! /bin/sh -eu
+#
+# [<php-version>] [<dependency-preference>] [<php-test-runtime>]
+#
+# <php-version>  example: php70
+# <dependency-preference> One of highest (default), lowest
+#
+# Both arguments can be a space separated value.
+# Example: "lowest highest"
+#
+
+# Configuration
+#
+dependencyPreferences='highest'
+skipPHPVersions='php8'
+
+# Commands
+#
+dcexec="docker-compose exec -u `id -u`:`id -g`"
+installSubmodule='git submodule update --checkout --recursive --force'
+composerUpdate='composer update --prefer-dist --no-suggest --optimize-autoloader'
+symfonyTestSuite='data/bin/symfony symfony:test --trace'
+
+# Parse arguments
+#
+phpVersions="${1-}"
+dependencyPreferences="${2-${dependencyPreferences}}"
+phpTestRuntime="${3-${symfonyTestSuite}}"
+
+script ()
+{
+  echo
+  echo
+  echo $0 ${1} ${2}
+  echo
+  ${dcexec} ${1} php data/bin/check_configuration.php
+  ${dcexec} ${1} php ${phpTestRuntime}
+}
+
+scriptAll ()
+{
+  for dependencyPreference in ${dependencyPreferences}
+  do
+    install_${dependencyPreference}
+
+    for phpVersion in ${phpVersions}
+    do
+      script ${phpVersion} ${dependencyPreference}
+    done
+  done
+}
+
+fetchAllPHPVersions ()
+{
+  docker-compose 2>/dev/null ps --services --filter status=running \
+    | grep php \
+    | sort \
+    | grep -v ${skipPHPVersions}
+}
+
+install_highest ()
+{
+  ${installSubmodule} --remote
+  ${dcexec} composer ${composerUpdate}
+}
+
+install_lowest ()
+{
+  reset_submodules
+
+  ${installSubmodule}
+  ${dcexec} composer ${composerUpdate} --prefer-lowest
+}
+
+reset_submodules ()
+{
+  git submodule deinit --force --quiet -- .
+
+  git submodule init
+}
+
+echo '+ docker-compose build'
+docker-compose up -d --build --remove-orphans > /dev/null
+
+test x"" != x"${phpVersions}" || {
+  phpVersions=`fetchAllPHPVersions`
+}
+
+scriptAll

--- a/test/unit/cache/sfMemcacheCacheTest.php
+++ b/test/unit/cache/sfMemcacheCacheTest.php
@@ -28,7 +28,15 @@ sfConfig::set('sf_logging_enabled', false);
 $t->diag('->initialize()');
 try
 {
-  $cache = new sfMemcacheCache(array('storeCacheInfo' => true));
+  $memcachedHost = getenv('MEMCACHED_HOST');
+  if (!$memcachedHost) {
+    $memcachedHost = null;
+  }
+
+  $cache = new sfMemcacheCache(array(
+    'storeCacheInfo' => true,
+    'host' => $memcachedHost,
+  ));
 }
 catch (sfInitializationException $e)
 {


### PR DESCRIPTION
Goal
----

* Removes all side work for contributors that do not provide any value, except effective improvements
* Provide the same testing environment for everyone.
* Help contributors to win the big challenge of PHP new versions supports, while BC layer are kept.
* Provide a bit more confidence during the development by reducing the testing feedback loop.

Usage
-----

Look at the README.md.

In short
```
test/bin/test
```

Test results
----------

### Same matrix than travis-ci

| PHP version | Dependency | Status
| ---- | ---- | ----
| php53 | highest | :green_circle:
| php54 | highest | :green_circle:
| php55 | highest | :green_circle:
| php56 | highest | :green_circle:
| php70 | highest | :green_circle:
| php71 | highest | :green_circle:
| php72 | highest | :green_circle:
| php73 | highest | :red_circle: 
| php74 | highest | :red_circle: 

```
#   at [sfDoctrine] functional/AdminGenTest.php line 17
>   response selector "select" matches "NewActivePendingExpired"
           got: '
New
Active
Pending
Expired
'
      expected: 'NewActivePendingExpired'
```

### New additional matrix (disabled by default)


| PHP version | Dependency | Status
| ---- | ---- | ----
| php53 | lowest | :green_circle:
| php54 | lowest | :green_circle:
| php55 | lowest | :green_circle:
| php56 | lowest | :green_circle:
| php70 | lowest | :green_circle:
| php71 | lowest | :green_circle:
| php72 | lowest | :green_circle:
| php73 | lowest | :red_circle: 
| php74 | lowest | :red_circle: 
| php80 | highest | :red_circle: 
| php81 | highest | :red_circle: 
| php80 | lowest | :red_circle: 
| php81 | lowest | :red_circle: 


Related to #261