### PR TITLE
Fix APC tests and add APCu support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,37 @@
 os: linux
-dist: xenial
+dist: focal
 language: php
 
 php:
-    - 7.0
-    - 7.1
-    - 7.2
-    - 7.3
-    - 7.4
-    - nightly
+  - 7.4
+  - 8.0
+  - 8.1
+  - nightly
 
 # run build against nightly but allow them to fail
 jobs:
     fast_finish: true
     allow_failures:
         - php: nightly
+        - php: 5.3
+        - php: 5.4
     include:
         - php: 5.3
           dist: precise
         - php: 5.4
-          dist: precise
+          dist: trusty
         - php: 5.5
           dist: trusty
         - php: 5.6
           dist: trusty
+        - php: 7.0
+          dist: xenial
+        - php: 7.1
+          dist: xenial
+        - php: 7.2
+          dist: xenial
+        - php: 7.3
+          dist: xenial
 
 services:
     - memcached
@@ -40,6 +48,8 @@ install:
     # by default, --remote is not used on travis
     - git submodule update --remote --force
     - composer install --prefer-dist --no-progress --no-suggest -o
+    # Temporary, while Doctrine is not merged, it will avoid one error tasksTest
+    - echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 script:
     - php data/bin/check_configuration.php

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All the enhancements and BC breaks are listed in the [WHATS_NEW](https://github.
 
 - [DIC](https://github.com/FriendsOfSymfony1/symfony1/wiki/ServiceContainer)
 - Composer support
-- PHP 7.2 support
+- PHP 8.1 support
 - performance boost
 - new widgets & validators
 - some tickets fixed from the symfony trac

--- a/data/bin/check_configuration.php
+++ b/data/bin/check_configuration.php
@@ -84,7 +84,7 @@ check(function_exists('utf8_decode'), 'The utf8_decode() is available', 'Install
 check(function_exists('posix_isatty'), 'The posix_isatty() is available', 'Install and enable the php_posix extension (used to colorized the CLI output)', false);
 
 $accelerator =
-  (function_exists('apc_store') && ini_get('apc.enabled'))
+  ((function_exists('apc_store') || function_exists('apcu_store')) && ini_get('apc.enabled'))
   ||
   function_exists('eaccelerator_put') && ini_get('eaccelerator.enable')
   ||

--- a/lib/addon/sfPager.class.php
+++ b/lib/addon/sfPager.class.php
@@ -529,6 +529,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
+  #[\ReturnTypeWillChange]
   public function current()
   {
     if (!$this->isIteratorInitialized())
@@ -544,6 +545,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
+  #[\ReturnTypeWillChange]
   public function key()
   {
     if (!$this->isIteratorInitialized())
@@ -559,6 +561,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
+  #[\ReturnTypeWillChange]
   public function next()
   {
     if (!$this->isIteratorInitialized())
@@ -576,6 +579,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
+  #[\ReturnTypeWillChange]
   public function rewind()
   {
     if (!$this->isIteratorInitialized())
@@ -593,6 +597,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
+  #[\ReturnTypeWillChange]
   public function valid()
   {
     if (!$this->isIteratorInitialized())
@@ -608,6 +613,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Countable
    */
+  #[\ReturnTypeWillChange]
   public function count()
   {
     return $this->getNbResults();

--- a/lib/autoload/sfCoreAutoload.class.php
+++ b/lib/autoload/sfCoreAutoload.class.php
@@ -194,6 +194,7 @@ class sfCoreAutoload
     'sfcoreautoload' => 'autoload/sfCoreAutoload.class.php',
     'sfsimpleautoload' => 'autoload/sfSimpleAutoload.class.php',
     'sfapccache' => 'cache/sfAPCCache.class.php',
+    'sfapcucache' => 'cache/sfAPCuCache.class.php',
     'sfcache' => 'cache/sfCache.class.php',
     'sfeacceleratorcache' => 'cache/sfEAcceleratorCache.class.php',
     'sffilecache' => 'cache/sfFileCache.class.php',

--- a/lib/cache/sfAPCuCache.class.php
+++ b/lib/cache/sfAPCuCache.class.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * This file is part of the symfony package.
+ * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Cache class that stores cached content in APCu.
+ *
+ * @package    symfony
+ * @subpackage cache
+ * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
+ * @author     Paulo M
+ * @version    SVN: $Id$
+ */
+class sfAPCuCache extends sfCache
+{
+  protected $enabled;
+
+  /**
+   * Initializes this sfCache instance.
+   *
+   * Available options:
+   *
+   * * see sfCache for options available for all drivers
+   *
+   * @see sfCache
+   * @inheritdoc
+   */
+  public function initialize($options = array())
+  {
+    parent::initialize($options);
+
+    $this->enabled = function_exists('apcu_store') && ini_get('apc.enabled');
+  }
+
+  /**
+   * @see sfCache
+   * @inheritdoc
+   */
+  public function get($key, $default = null)
+  {
+    if (!$this->enabled)
+    {
+      return $default;
+    }
+
+    $value = $this->fetch($this->getOption('prefix').$key, $has);
+
+    return $has ? $value : $default;
+  }
+
+  /**
+   * @see sfCache
+   * @inheritdoc
+   */
+  public function has($key)
+  {
+    if (!$this->enabled)
+    {
+      return false;
+    }
+
+    $this->fetch($this->getOption('prefix').$key, $has);
+
+    return $has;
+  }
+
+  private function fetch($key, &$success)
+  {
+    $has = null;
+    $value = apcu_fetch($key, $has);
+    // the second argument was added in APC 3.0.17. If it is still null we fall back to the value returned
+    if (null !== $has)
+    {
+      $success = $has;
+    }
+    else
+    {
+      $success = $value !== false;
+    }
+
+    return $value;
+  }
+
+
+  /**
+   * @see sfCache
+   * @inheritdoc
+   */
+  public function set($key, $data, $lifetime = null)
+  {
+    if (!$this->enabled)
+    {
+      return true;
+    }
+
+    return apcu_store($this->getOption('prefix').$key, $data, $this->getLifetime($lifetime));
+  }
+
+  /**
+   * @see sfCache
+   * @inheritdoc
+   */
+  public function remove($key)
+  {
+    if (!$this->enabled)
+    {
+      return true;
+    }
+
+    return apcu_delete($this->getOption('prefix').$key);
+  }
+
+  /**
+   * @see sfCache
+   * @inheritdoc
+   */
+  public function clean($mode = sfCache::ALL)
+  {
+    if (!$this->enabled)
+    {
+      return true;
+    }
+
+    if (sfCache::ALL === $mode)
+    {
+      return apcu_clear_cache();
+    }
+  }
+
+  /**
+   * @see sfCache
+   * @inheritdoc
+   */
+  public function getLastModified($key)
+  {
+    if ($info = $this->getCacheInfo($key))
+    {
+      return $info['creation_time'] + $info['ttl'] > time() ? $info['mtime'] : 0;
+    }
+
+    return 0;
+  }
+
+  /**
+   * @see sfCache
+   * @inheritdoc
+   */
+  public function getTimeout($key)
+  {
+    if ($info = $this->getCacheInfo($key))
+    {
+      return $info['creation_time'] + $info['ttl'] > time() ? $info['creation_time'] + $info['ttl'] : 0;
+    }
+
+    return 0;
+  }
+
+  /**
+   * @see sfCache
+   * @inheritdoc
+   */
+  public function removePattern($pattern)
+  {
+    if (!$this->enabled)
+    {
+      return true;
+    }
+
+    $infos = apcu_cache_info();
+    if (!is_array($infos['cache_list']))
+    {
+      return;
+    }
+
+    $regexp = self::patternToRegexp($this->getOption('prefix').$pattern);
+
+    foreach ($infos['cache_list'] as $info)
+    {
+      if (preg_match($regexp, $info['info']))
+      {
+        apcu_delete($info['info']);
+      }
+    }
+  }
+
+  /**
+   * Gets the cache info
+   *
+   * @param  string $key The cache key
+   *
+   * @return string
+   */
+  protected function getCacheInfo($key)
+  {
+    if (!$this->enabled)
+    {
+      return false;
+    }
+
+    $infos = apcu_cache_info();
+
+    if (is_array($infos['cache_list']))
+    {
+      foreach ($infos['cache_list'] as $info)
+      {
+        if ($this->getOption('prefix').$key == $info['info'])
+        {
+          return $info;
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/lib/cache/sfFileCache.class.php
+++ b/lib/cache/sfFileCache.class.php
@@ -256,7 +256,15 @@ class sfFileCache extends sfCache
         fseek($fp, 0, SEEK_END);
         $length = ftell($fp) - 24;
         fseek($fp, 24);
-        $data[self::READ_DATA] = @fread($fp, $length);
+
+        if ($length > 0)
+        {
+          $data[self::READ_DATA] = @fread($fp, $length);
+        }
+        else
+        {
+          $data[self::READ_DATA] = '';
+        }
       }
     }
     else

--- a/lib/database/sfMySQLiDatabase.class.php
+++ b/lib/database/sfMySQLiDatabase.class.php
@@ -29,6 +29,9 @@ class sfMySQLiDatabase extends sfMySQLDatabase
    */
   protected function getConnectMethod($persistent)
   {
+    // PHP 8.1 Activate Exception per default, revert behavior to "return false"
+    mysqli_report(MYSQLI_REPORT_OFF);
+
     return 'mysqli_connect';
   }
 

--- a/lib/escaper/sfOutputEscaperArrayDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperArrayDecorator.class.php
@@ -42,6 +42,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
   /**
    * Reset the array to the beginning (as required for the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function rewind()
   {
     reset($this->value);
@@ -54,6 +55,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return string The key
    */
+  #[\ReturnTypeWillChange]
   public function key()
   {
     return key($this->value);
@@ -67,6 +69,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return mixed The escaped value
    */
+  #[\ReturnTypeWillChange]
   public function current()
   {
     return sfOutputEscaper::escape($this->escapingMethod, current($this->value));
@@ -75,6 +78,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
   /**
    * Moves to the next element (as required by the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function next()
   {
     next($this->value);
@@ -91,6 +95,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return bool The validity of the current element; true if it is valid
    */
+  #[\ReturnTypeWillChange]
   public function valid()
   {
     return $this->count > 0;
@@ -103,6 +108,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return bool true if the offset isset; false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     return isset($this->value[$offset]);
@@ -115,6 +121,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return mixed The escaped value
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->value[$offset]);
@@ -132,6 +139,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     throw new sfException('Cannot set values.');
@@ -148,6 +156,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     throw new sfException('Cannot unset values.');
@@ -158,6 +167,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return int The size of the array
    */
+  #[\ReturnTypeWillChange]
   public function count()
   {
     return count($this->value);

--- a/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
@@ -56,6 +56,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return void
    */
+  #[\ReturnTypeWillChange]
   public function rewind()
   {
     return $this->iterator->rewind();
@@ -66,6 +67,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return mixed The escaped value
    */
+  #[\ReturnTypeWillChange]
   public function current()
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->iterator->current());
@@ -76,6 +78,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return string Iterator key
    */
+  #[\ReturnTypeWillChange]
   public function key()
   {
     return $this->iterator->key();
@@ -86,6 +89,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return void
    */
+  #[\ReturnTypeWillChange]
   public function next()
   {
     return $this->iterator->next();
@@ -97,6 +101,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return bool true if the current element is valid; false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function valid()
   {
     return $this->iterator->valid();
@@ -109,6 +114,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return bool true if the offset isset; false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     return isset($this->value[$offset]);
@@ -121,6 +127,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return mixed The escaped value
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->value[$offset]);
@@ -138,6 +145,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @throws sfException
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     throw new sfException('Cannot set values.');
@@ -154,6 +162,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @throws sfException
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     throw new sfException('Cannot unset values.');

--- a/lib/escaper/sfOutputEscaperObjectDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperObjectDecorator.class.php
@@ -111,12 +111,18 @@ class sfOutputEscaperObjectDecorator extends sfOutputEscaperGetterDecorator impl
   /**
    * Returns the size of the object if it implements Countable (is required by the Countable interface).
    *
-   * It returns 1 if other cases (which is the default PHP behavior in such a case).
+   * It returns 1 if other cases (which was the default PHP behavior in such a case before php 7.3).
    *
    * @return int The size of the object
    */
+  #[\ReturnTypeWillChange]
   public function count()
   {
-    return count($this->value);
+    // See https://github.com/symfony/polyfill/commit/d330c0094a47d8edceeea1ed553d6e08215a9fc2
+    if (is_array($this->value) || $this->value instanceof Countable || $this->value instanceof ResourceBundle || $this->value instanceof SimpleXmlElement)
+    {
+      return count($this->value);
+    }
+    return 1;
   }
 }

--- a/lib/event/sfEvent.class.php
+++ b/lib/event/sfEvent.class.php
@@ -83,7 +83,7 @@ class sfEvent implements ArrayAccess
   /**
    * Sets the processed flag.
    *
-   * @param Boolean $processed The processed flag value
+   * @param boolean $processed The processed flag value
    */
   public function setProcessed($processed)
   {
@@ -117,6 +117,7 @@ class sfEvent implements ArrayAccess
    *
    * @return Boolean true if the parameter exists, false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($name)
   {
     return array_key_exists($name, $this->parameters);
@@ -129,6 +130,7 @@ class sfEvent implements ArrayAccess
    *
    * @return mixed  The parameter value
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($name)
   {
     if (!array_key_exists($name, $this->parameters))
@@ -145,6 +147,7 @@ class sfEvent implements ArrayAccess
    * @param string  $name   The parameter name
    * @param mixed   $value  The parameter value
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($name, $value)
   {
     $this->parameters[$name] = $value;
@@ -155,6 +158,7 @@ class sfEvent implements ArrayAccess
    *
    * @param string $name    The parameter name
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($name)
   {
     unset($this->parameters[$name]);

--- a/lib/exception/sfException.class.php
+++ b/lib/exception/sfException.class.php
@@ -366,6 +366,12 @@ class sfException extends Exception
    */
   static protected function fileExcerpt($file, $line)
   {
+    // $file can be null for RuntimeException
+    if ($file === null)
+    {
+      return '';
+    }
+
     if (is_readable($file))
     {
       $content = preg_split('#<br />#', preg_replace('/^<code>(.*)<\/code>$/s', '$1', highlight_file($file, true)));

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1064,6 +1064,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return Boolean true if the widget exists, false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($name)
   {
     return isset($this->widgetSchema[$name]);
@@ -1076,6 +1077,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return sfFormField|sfFormFieldSchema A form field instance
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($name)
   {
     if (!isset($this->formFields[$name]))
@@ -1114,6 +1116,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @throws <b>LogicException</b>
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     throw new LogicException('Cannot update form fields.');
@@ -1126,6 +1129,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @param string $offset The field name
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     unset(
@@ -1227,6 +1231,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Resets the field names array to the beginning (implements the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function rewind()
   {
     $this->fieldNames = $this->widgetSchema->getPositions();
@@ -1240,6 +1245,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return string The key
    */
+  #[\ReturnTypeWillChange]
   public function key()
   {
     return current($this->fieldNames);
@@ -1250,6 +1256,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return mixed The escaped value
    */
+  #[\ReturnTypeWillChange]
   public function current()
   {
     return $this[current($this->fieldNames)];
@@ -1258,6 +1265,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Moves to the next form field (implements the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function next()
   {
     next($this->fieldNames);
@@ -1269,6 +1277,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return boolean The validity of the current element; true if it is valid
    */
+  #[\ReturnTypeWillChange]
   public function valid()
   {
     return $this->count > 0;
@@ -1279,6 +1288,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return integer The number of embedded form fields
    */
+  #[\ReturnTypeWillChange]
   public function count()
   {
     return count($this->getFormFieldSchema());

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -91,6 +91,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return Boolean true if the widget exists, false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($name)
   {
     return isset($this->widget[$name]);
@@ -103,6 +104,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return sfFormField A form field instance
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($name)
   {
     if (!isset($this->fields[$name]))
@@ -144,6 +146,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @throws LogicException
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     throw new LogicException('Cannot update form fields (read-only).');
@@ -156,6 +159,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @throws LogicException
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     throw new LogicException('Cannot remove form fields (read-only).');
@@ -164,6 +168,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
   /**
    * Resets the field names array to the beginning (implements the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function rewind()
   {
     reset($this->fieldNames);
@@ -175,6 +180,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return string The key
    */
+  #[\ReturnTypeWillChange]
   public function key()
   {
     return current($this->fieldNames);
@@ -185,6 +191,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return mixed The escaped value
    */
+  #[\ReturnTypeWillChange]
   public function current()
   {
     return $this[current($this->fieldNames)];
@@ -193,6 +200,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
   /**
    * Moves to the next form field (implements the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function next()
   {
     next($this->fieldNames);
@@ -204,6 +212,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return boolean The validity of the current element; true if it is valid
    */
+  #[\ReturnTypeWillChange]
   public function valid()
   {
     return $this->count > 0;
@@ -214,6 +223,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return integer The number of embedded form fields
    */
+  #[\ReturnTypeWillChange]
   public function count()
   {
     return count($this->fieldNames);

--- a/lib/helper/DateHelper.php
+++ b/lib/helper/DateHelper.php
@@ -17,7 +17,7 @@
  * @version    SVN: $Id$
  */
 
-function format_daterange($start_date, $end_date, $format = 'd', $full_text, $start_text, $end_text, $culture = null, $charset = null)
+function format_daterange($start_date, $end_date, $format = 'd', $full_text = '', $start_text = '', $end_text = '', $culture = null, $charset = null)
 {
   if ($start_date != '' && $end_date != '')
   {

--- a/lib/helper/I18NHelper.php
+++ b/lib/helper/I18NHelper.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -60,7 +60,7 @@ function __($text, $args = array(), $catalogue = 'messages')
  *
  * @return string Result of the translation
  */
-function format_number_choice($text, $args = array(), $number, $catalogue = 'messages')
+function format_number_choice($text, $args = array(), $number = null, $catalogue = 'messages')
 {
   $translated = __($text, $args, $catalogue);
 

--- a/lib/i18n/sfCultureInfo.class.php
+++ b/lib/i18n/sfCultureInfo.class.php
@@ -92,11 +92,11 @@ class sfCultureInfo
    * @var sfNumberFormatInfo
    */
   protected $numberFormat;
-  
+
   /**
    * A list of properties that are accessable/writable.
    * @var array
-   */ 
+   */
   protected $properties = array();
 
   /**
@@ -191,9 +191,9 @@ class sfCultureInfo
   }
 
   /**
-   * Initializes a new instance of the sfCultureInfo class based on the 
+   * Initializes a new instance of the sfCultureInfo class based on the
    * culture specified by name. E.g. <code>new sfCultureInfo('en_AU');</code>
-   * The culture indentifier must be of the form 
+   * The culture indentifier must be of the form
    * "<language>_(country/region/variant)".
    *
    * @param string $culture a culture name, e.g. "en_AU".
@@ -323,7 +323,7 @@ class sfCultureInfo
    * this function.
    *
    * @param string $filename the ICU data filename
-   * @return array ICU data 
+   * @return array ICU data
    */
   protected function &getData($filename)
   {
@@ -347,7 +347,7 @@ class sfCultureInfo
    * Use merge=true to return the ICU including the parent culture.
    * E.g. The currency data for a variant, say "en_AU" contains one
    * entry, the currency for AUD, the other currency data are stored
-   * in the "en" data file. Thus to retrieve all the data regarding 
+   * in the "en" data file. Thus to retrieve all the data regarding
    * currency for "en_AU", you need to use findInfo("Currencies,true);.
    *
    * @param string  $path   the data you want to find.
@@ -429,9 +429,9 @@ class sfCultureInfo
       }
     }
   }
-  
+
   /**
-   * Gets the culture name in the format 
+   * Gets the culture name in the format
    * "<languagecode2>_(country/regioncode2)".
    *
    * @return string culture name.
@@ -516,7 +516,7 @@ class sfCultureInfo
     $culture = $this->getInvariantCulture();
 
     $language = $culture->findInfo("Languages/{$lang}");
-    if (count($language) == 0)
+    if (is_array($language) && count($language) == 0)
     {
       return $this->culture;
     }
@@ -547,7 +547,7 @@ class sfCultureInfo
   }
 
   /**
-   * Gets a value indicating whether the current sfCultureInfo 
+   * Gets a value indicating whether the current sfCultureInfo
    * represents a neutral culture. Returns true if the culture
    * only contains two characters.
    *
@@ -590,7 +590,7 @@ class sfCultureInfo
   }
 
   /**
-   * Gets the sfCultureInfo that represents the parent culture of the 
+   * Gets the sfCultureInfo that represents the parent culture of the
    * current sfCultureInfo
    *
    * @return sfCultureInfo parent culture information.
@@ -606,14 +606,14 @@ class sfCultureInfo
   }
 
   /**
-   * Gets the list of supported cultures filtered by the specified 
+   * Gets the list of supported cultures filtered by the specified
    * culture type. This is an EXPENSIVE function, it needs to traverse
    * a list of ICU files in the data directory.
    * This function can be called statically.
    *
    * @param int $type culture type, sfCultureInfo::ALL, sfCultureInfo::NEUTRAL
    * or sfCultureInfo::SPECIFIC.
-   * @return array list of culture information available. 
+   * @return array list of culture information available.
    */
   static function getCultures($type = sfCultureInfo::ALL)
   {
@@ -719,7 +719,7 @@ class sfCultureInfo
    *
    * @param  array $countries An array of countries used to restrict the returned array (null by default, which means all countries)
    *
-   * @return array a list of localized country names. 
+   * @return array a list of localized country names.
    */
   public function getCountries($countries = null)
   {

--- a/lib/i18n/sfDateFormat.class.php
+++ b/lib/i18n/sfDateFormat.class.php
@@ -239,9 +239,10 @@ class sfDateFormat
       }
       else
       {
-        $function = ucfirst($this->getFunctionName($pattern));
+        $function = $this->getFunctionName($pattern);
         if ($function != null)
         {
+          $function = ucfirst($function);
           $fName = 'get'.$function;
           if (in_array($fName, $this->methods))
           {

--- a/lib/i18n/sfI18N.class.php
+++ b/lib/i18n/sfI18N.class.php
@@ -271,6 +271,15 @@ class sfI18N
     list($day, $month, $year) = $this->getDateForCulture($dateTime, null === $culture ? $this->culture : $culture);
     list($hour, $minute) = $this->getTimeForCulture($dateTime, null === $culture ? $this->culture : $culture);
 
+    // mktime behavior change with php8
+    // $hour become not nullable
+    if (!$hour) {
+      $hour = 0;
+    }
+    // Before 8.0, $minutes value to null, was casted as (int)0
+    if (!$minute) {
+      $minute = 0;
+    }
     return null === $day ? null : mktime($hour, $minute, 0, $month, $day, $year);
   }
 

--- a/lib/log/sfFileLogger.class.php
+++ b/lib/log/sfFileLogger.class.php
@@ -92,7 +92,7 @@ class sfFileLogger extends sfLogger
    * Logs a message.
    *
    * @param string $message   Message
-   * @param int    $priority  Message priority
+   * @param int $priority  Message priority
    */
   protected function doLog($message, $priority)
   {
@@ -100,7 +100,7 @@ class sfFileLogger extends sfLogger
     fwrite($this->fp, strtr($this->format, array(
       '%type%'     => $this->type,
       '%message%'  => $message,
-      '%time%'     => strftime($this->timeFormat),
+      '%time%'     => self::strftime($this->timeFormat),
       '%priority%' => $this->getPriority($priority),
       '%EOL%'      => PHP_EOL,
     )));
@@ -128,5 +128,61 @@ class sfFileLogger extends sfLogger
     {
       fclose($this->fp);
     }
+  }
+
+  /**
+   * @param $format
+   * @return false|string
+   */
+  public static function strftime($format)
+  {
+    if (version_compare(PHP_VERSION, '8.1.0') < 0) {
+      return strftime($format);
+    }
+    return date(self::_strftimeFormatToDateFormat($format));
+  }
+
+  /**
+   * Try to Convert a strftime to date format
+   *
+   * Unable to find a perfect implementation, based on those one (Each contains some errors)
+   * https://github.com/Fabrik/fabrik/blob/master/plugins/fabrik_element/date/date.php
+   * https://gist.github.com/mcaskill/02636e5970be1bb22270
+   * https://stackoverflow.com/questions/22665959/using-php-strftime-using-date-format-string
+   *
+   * Limitation:
+   * - Do not apply translation
+   * - Some few strftime format could be broken (low probability to be used on logs)
+   *
+   * Private: because it should not be used outside of this scope
+   *
+   * A better solution is to use : IntlDateFormatter, but it will require to load a new php extension, which could break some setup.
+   *
+   * @return array|string|string[]
+   */
+  private static function _strftimeFormatToDateFormat($strftimeFormat) {
+
+    // Missing %V %C %g %G
+    $search = array(
+      '%a', '%A', '%d', '%e', '%u',
+      '%w', '%W', '%b', '%h', '%B',
+      '%m', '%y', '%Y', '%D', '%F',
+      '%x', '%n', '%t', '%H', '%k',
+      '%I', '%l', '%M', '%p', '%P',
+      '%r' /* %I:%M:%S %p */, '%R' /* %H:%M */, '%S', '%T' /* %H:%M:%S */, '%X', '%z', '%Z',
+      '%c', '%s', '%j',
+      '%%');
+
+    $replace = array(
+      'D', 'l', 'd', 'j', 'N',
+      'w', 'W', 'M', 'M', 'F',
+      'm', 'y', 'Y', 'm/d/y', 'Y-m-d',
+      'm/d/y', "\n", "\t", 'H', 'G',
+      'h', 'g', 'i', 'A', 'a',
+      'h:i:s A', 'H:i', 's', 'H:i:s', 'H:i:s', 'O', 'T',
+      'D M j H:i:s Y' /*Tue Feb 5 00:45:10 2009*/, 'U', 'z',
+      '%');
+
+    return str_replace($search, $replace, $strftimeFormat);
   }
 }

--- a/lib/plugin/sfPearRest.class.php
+++ b/lib/plugin/sfPearRest.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -23,7 +23,7 @@ class sfPearRest extends PEAR_REST
   /**
    * @see PEAR_REST::downloadHttp()
    */
-  public function downloadHttp($url, $lastmodified = null, $accept = false)
+  public function downloadHttp($url, $lastmodified = null, $accept = false, $channel = false)
   {
     return parent::downloadHttp($url, $lastmodified, array_merge(false !== $accept ? $accept : array(), array("\r\nX-SYMFONY-VERSION: ".SYMFONY_VERSION)));
   }

--- a/lib/plugins/sfDoctrinePlugin/lib/database/sfDoctrineConnectionProfiler.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/database/sfDoctrineConnectionProfiler.class.php
@@ -200,7 +200,7 @@ class sfDoctrineConnectionProfiler extends Doctrine_Connection_Profiler
 
     foreach ($params as $key => $param)
     {
-      if (strlen($param) >= 255)
+      if ($param && strlen($param) >= 255)
       {
         $params[$key] = '['.number_format(strlen($param) / 1024, 2).'Kb]';
       }

--- a/lib/plugins/sfDoctrinePlugin/lib/debug/sfWebDebugPanelDoctrine.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/debug/sfWebDebugPanelDoctrine.class.php
@@ -68,7 +68,7 @@ class sfWebDebugPanelDoctrine extends sfWebDebugPanel
 
   /**
    * Returns an array of Doctrine query events.
-   * 
+   *
    * @return array
    */
   protected function getDoctrineEvents()
@@ -116,7 +116,7 @@ class sfWebDebugPanelDoctrine extends sfWebDebugPanel
       // interpolate parameters
       foreach ($params as $param)
       {
-        $param = htmlspecialchars($param, ENT_QUOTES, sfConfig::get('sf_charset'));
+        $param = htmlspecialchars((string) $param, ENT_QUOTES, sfConfig::get('sf_charset'));
         $query = join(var_export(is_scalar($param) ? $param : (string) $param, true), explode('?', $query, 2));
       }
 

--- a/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineColumn.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineColumn.class.php
@@ -349,21 +349,25 @@ class sfDoctrineColumn implements ArrayAccess
     return $this->table;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     return isset($this->definition[$offset]);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $this->definition[$offset] = $value;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     return $this->definition[$offset];
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     unset($this->definition[$offset]);

--- a/lib/plugins/sfDoctrinePlugin/lib/pager/sfDoctrinePager.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/pager/sfDoctrinePager.class.php
@@ -52,9 +52,7 @@ class sfDoctrinePager extends sfPager implements Serializable
    */
   public function serialize()
   {
-    $vars = get_object_vars($this);
-    unset($vars['query']);
-    return serialize($vars);
+    return serialize($this->__serialize());
   }
 
   /**
@@ -66,12 +64,35 @@ class sfDoctrinePager extends sfPager implements Serializable
   {
     $array = unserialize($serialized);
 
-    foreach ($array as $name => $values)
+    return $this->__unserialize($array);
+  }
+
+  /**
+   * Serializes the current instance for php 7.4+
+   *
+   * @return array
+   */
+  public function __serialize()
+  {
+    $vars = get_object_vars($this);
+    unset($vars['query']);
+    return $vars;
+  }
+
+  /**
+   * Unserializes a sfDoctrinePager instance for php 7.4+
+   *
+   * @param array $data
+   */
+  public function __unserialize($data)
+  {
+
+    foreach ($data as $name => $values)
     {
-      $this->$name = $values;
+       $this->$name = $values;
     }
 
-    $this->tableMethodCalled = false; 
+    $this->tableMethodCalled = false;
   }
 
   /**

--- a/lib/plugins/sfDoctrinePlugin/lib/test/sfTesterDoctrine.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/test/sfTesterDoctrine.class.php
@@ -65,7 +65,7 @@ class sfTesterDoctrine extends sfTester
         }
 
         $operator = '=';
-        if ('!' == $condition[0])
+        if (strlen($condition) && '!' == substr($condition,0,1))
         {
           $operator = false !== strpos($condition, '%') ? 'NOT LIKE' : '!=';
           $condition = substr($condition, 1);
@@ -103,7 +103,7 @@ class sfTesterDoctrine extends sfTester
 
   /**
    * Outputs some debug information about queries run during the current request.
-   * 
+   *
    * @param integer|string $limit Either an integer to return the last many queries, a regular expression or a substring to search for
    */
   public function debug($limit = null)

--- a/lib/plugins/sfDoctrinePlugin/test/functional/AdminGenBrowser.class.php
+++ b/lib/plugins/sfDoctrinePlugin/test/functional/AdminGenBrowser.class.php
@@ -152,7 +152,7 @@ class AdminGenBrowser extends sfTestBrowser
     $this->
       get('/subscriptions/new')->
         with('response')->begin()->
-          checkElement('select', 'NewActivePendingExpired')->
+          checkElement('select', '/^New\R?Active\R?Pending\R?Expired\R?$/m')->
         end()
     ;
   }
@@ -237,7 +237,7 @@ class AdminGenBrowser extends sfTestBrowser
   }
 
   protected function _generateAdminGenModule($model, $module)
-  {    
+  {
     $this->info('Generating admin gen module "' . $module . '"');
     $task = new sfDoctrineGenerateAdminTask($this->getContext()->getEventDispatcher(), new sfFormatter());
     $task->run(array('application' => 'backend', 'route_or_model' => $model));

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -173,6 +173,7 @@ abstract class sfRequest implements ArrayAccess
    *
    * @return bool true if the request parameter exists, false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($name)
   {
     return $this->hasParameter($name);
@@ -185,6 +186,7 @@ abstract class sfRequest implements ArrayAccess
    *
    * @return mixed The request parameter if exists, null otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($name)
   {
     return $this->getParameter($name, false);
@@ -196,6 +198,7 @@ abstract class sfRequest implements ArrayAccess
    * @param string $offset The parameter name
    * @param string $value The parameter value
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $this->setParameter($offset, $value);
@@ -206,6 +209,7 @@ abstract class sfRequest implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $this->getParameterHolder()->remove($offset);

--- a/lib/response/sfResponse.class.php
+++ b/lib/response/sfResponse.class.php
@@ -152,7 +152,7 @@ abstract class sfResponse implements Serializable
   /**
    * Serializes the current instance.
    *
-   * @return array Objects instance
+   * @return string Objects instance
    */
   public function serialize()
   {
@@ -170,5 +170,24 @@ abstract class sfResponse implements Serializable
   public function unserialize($serialized)
   {
     $this->content = unserialize($serialized);
+  }
+
+  /**
+   * Serializes the current instance for php 7.4+
+   *
+   * @return array
+   */
+  public function __serialize() {
+    return array('content' => $this->content);
+  }
+
+  /**
+   * Unserializes a sfResponse instance for php 7.4+
+   *
+   * @param array $data
+  */
+  public function __unserialize($data)
+  {
+    $this->content = $data['content'];
   }
 }

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -158,10 +158,11 @@ class sfWebResponse extends sfResponse
    * @param  string  $domain    Domain name
    * @param  bool    $secure    If secure
    * @param  bool    $httpOnly  If uses only HTTP
+   * @param  string  $samesite  SameSite cookies
    *
    * @throws <b>sfException</b> If fails to set the cookie
    */
-  public function setCookie($name, $value, $expire = null, $path = '/', $domain = '', $secure = false, $httpOnly = false)
+  public function setCookie($name, $value, $expire = null, $path = '/', $domain = '', $secure = false, $httpOnly = false, $samesite = '')
   {
     if ($expire !== null)
     {
@@ -187,6 +188,7 @@ class sfWebResponse extends sfResponse
       'domain'   => $domain,
       'secure'   => $secure ? true : false,
       'httpOnly' => $httpOnly,
+      'samesite' => $samesite
     );
   }
 
@@ -365,7 +367,18 @@ class sfWebResponse extends sfResponse
     // cookies
     foreach ($this->cookies as $cookie)
     {
-      setrawcookie($cookie['name'], $cookie['value'], $cookie['expire'], $cookie['path'], $cookie['domain'], $cookie['secure'], $cookie['httpOnly']);
+      if (PHP_VERSION_ID < 70300) {
+        setrawcookie($cookie['name'], $cookie['value'], $cookie['expire'], $cookie['path'], $cookie['domain'], $cookie['secure'], $cookie['httpOnly']);
+      } else {
+        setrawcookie($cookie['name'], $cookie['value'], array(
+          'expires'  => $cookie['expire'],
+          'path'     => $cookie['path'],
+          'domain'   => $cookie['domain'],
+          'secure'   => $cookie['secure'],
+          'httpOnly' => $cookie['httpOnly'],
+          'samesite' => $cookie['samesite'],
+        ));
+      }
 
       if ($this->options['logging'])
       {

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -314,7 +314,7 @@ class sfWebResponse extends sfResponse
   /**
    * Gets response content type.
    *
-   * @return array
+   * @return string
    */
   public function getContentType()
   {
@@ -889,7 +889,7 @@ class sfWebResponse extends sfResponse
    */
   public function serialize()
   {
-    return serialize(array($this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots));
+    return serialize($this->__serialize());
   }
 
   /**
@@ -898,7 +898,25 @@ class sfWebResponse extends sfResponse
    */
   public function unserialize($serialized)
   {
-    list($this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots) = unserialize($serialized);
+    $this->__unserialize(unserialize($serialized));
+  }
+
+  /**
+   * @see sfResponse
+   * @return array
+   */
+  public function __serialize()
+  {
+    return array($this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots);
+  }
+
+  /**
+   * @see sfResponse
+   * @param array $data
+   */
+  public function __unserialize($data)
+  {
+    list($this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots) = $data;
   }
 
   /**

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -264,7 +264,7 @@ class sfRoute implements Serializable
 
   static private function generateCompareVarsByStrlen($a, $b)
   {
-    return strlen($a) < strlen($b);
+    return (strlen($a) < strlen($b)) ? 1 : -1;
   }
 
   /**
@@ -285,7 +285,7 @@ class sfRoute implements Serializable
       switch ($token[0])
       {
         case 'variable':
-          if (!$optional || !isset($this->defaults[$token[3]]) || $parameters[$token[3]] != $this->defaults[$token[3]])
+          if (!$optional || !isset($this->defaults[$token[3]]) || (isset($parameters[$token[3]]) && $parameters[$token[3]] != $this->defaults[$token[3]]))
           {
             $url[] = urlencode($parameters[$token[3]]);
             $optional = false;
@@ -791,7 +791,7 @@ class sfRoute implements Serializable
       }
       else
       {
-        $this->defaults[$key] = urldecode($value);
+        $this->defaults[$key] = urldecode((string) $value);
       }
     }
   }
@@ -847,15 +847,37 @@ class sfRoute implements Serializable
 
   public function serialize()
   {
+    return serialize($this->__serialize());
+  }
+
+  public function unserialize($serialized)
+  {
+    $array = unserialize($serialized);
+
+    $this->__unserialize($array);
+  }
+
+  /**
+   * Serializes the current instance for php 7.4+
+   *
+   * @return array
+   */
+  public function __serialize() {
     // always serialize compiled routes
     $this->compile();
     // sfPatternRouting will always re-set defaultParameters, so no need to serialize them
-    return serialize(array($this->tokens, $this->defaultOptions, $this->options, $this->pattern, $this->staticPrefix, $this->regex, $this->variables, $this->defaults, $this->requirements, $this->suffix, $this->customToken));
+    return array($this->tokens, $this->defaultOptions, $this->options, $this->pattern, $this->staticPrefix, $this->regex, $this->variables, $this->defaults, $this->requirements, $this->suffix, $this->customToken);
   }
 
-  public function unserialize($data)
+  /**
+   * Unserializes a sfRoute instance for php 7.4+
+   *
+   * @param array $data
+   */
+  public function __unserialize($data)
   {
-    list($this->tokens, $this->defaultOptions, $this->options, $this->pattern, $this->staticPrefix, $this->regex, $this->variables, $this->defaults, $this->requirements, $this->suffix, $this->customToken) = unserialize($data);
+    list($this->tokens, $this->defaultOptions, $this->options, $this->pattern, $this->staticPrefix, $this->regex, $this->variables, $this->defaults, $this->requirements, $this->suffix, $this->customToken) = $data;
+
     $this->compiled = true;
   }
 }

--- a/lib/routing/sfRouteCollection.class.php
+++ b/lib/routing/sfRouteCollection.class.php
@@ -61,6 +61,7 @@ class sfRouteCollection implements Iterator
   /**
    * Reset the error array to the beginning (implements the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function rewind()
   {
     reset($this->routes);
@@ -73,6 +74,7 @@ class sfRouteCollection implements Iterator
    *
    * @return string The key
    */
+  #[\ReturnTypeWillChange]
   public function key()
   {
     return key($this->routes);
@@ -83,6 +85,7 @@ class sfRouteCollection implements Iterator
    *
    * @return mixed The escaped value
    */
+  #[\ReturnTypeWillChange]
   public function current()
   {
     return current($this->routes);
@@ -91,6 +94,7 @@ class sfRouteCollection implements Iterator
   /**
    * Moves to the next route (implements the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function next()
   {
     next($this->routes);
@@ -103,6 +107,7 @@ class sfRouteCollection implements Iterator
    *
    * @return boolean The validity of the current route; true if it is valid
    */
+  #[\ReturnTypeWillChange]
   public function valid()
   {
     return $this->count > 0;

--- a/lib/storage/sfSessionStorage.class.php
+++ b/lib/storage/sfSessionStorage.class.php
@@ -203,5 +203,6 @@ class sfSessionStorage extends sfStorage
   {
     // don't need a shutdown procedure because read/write do it in real-time
     session_write_close();
+    self::$sessionStarted = false;
   }
 }

--- a/lib/storage/sfSessionStorage.class.php
+++ b/lib/storage/sfSessionStorage.class.php
@@ -62,6 +62,7 @@ class sfSessionStorage extends sfStorage
       'session_cookie_domain'   => $cookieDefaults['domain'],
       'session_cookie_secure'   => $cookieDefaults['secure'],
       'session_cookie_httponly' => isset($cookieDefaults['httponly']) ? $cookieDefaults['httponly'] : false,
+      'session_cookie_samesite' => isset($cookieDefaults['samesite']) ? $cookieDefaults['samesite'] : '',
       'session_cache_limiter'   => null,
       'gc_maxlifetime'          => 1800,
     ), $options);
@@ -84,7 +85,19 @@ class sfSessionStorage extends sfStorage
     $domain   = $this->options['session_cookie_domain'];
     $secure   = $this->options['session_cookie_secure'];
     $httpOnly = $this->options['session_cookie_httponly'];
-    session_set_cookie_params($lifetime, $path, $domain, $secure, $httpOnly);
+    $samesite = $this->options['session_cookie_samesite'];
+    if (PHP_VERSION_ID < 70300) {
+      session_set_cookie_params($lifetime, $path, $domain, $secure, $httpOnly);
+    } else {
+      session_set_cookie_params(array(
+        'lifetime' => $lifetime,
+        'path'     => $path,
+        'domain'   => $domain,
+        'secure'   => $secure,
+        'httponly' => $httpOnly,
+        'samesite' => $samesite
+      ));
+    }
 
     if (null !== $this->options['session_cache_limiter'])
     {

--- a/lib/test/sfTestFunctionalBase.class.php
+++ b/lib/test/sfTestFunctionalBase.class.php
@@ -478,7 +478,7 @@ abstract class sfTestFunctionalBase
   /**
    * Exception handler for the current test browser instance.
    *
-   * @param Exception $exception The exception
+   * @param Throwable $exception The exception
    */
   function handleException($exception)
   {

--- a/lib/test/sfTesterResponse.class.php
+++ b/lib/test/sfTesterResponse.class.php
@@ -49,7 +49,10 @@ class sfTesterResponse extends sfTester
       }
       else
       {
-        @$this->dom->loadHTML($this->response->getContent());
+        if ($this->response->getContent())
+        {
+          @$this->dom->loadHTML($this->response->getContent());
+        }
       }
       $this->domCssSelector = new sfDomCssSelector($this->dom);
     }
@@ -120,10 +123,10 @@ class sfTesterResponse extends sfTester
 
   /**
    * Checks that a form is rendered correctly.
-   * 
+   *
    * @param  sfForm|string $form     A form object or the name of a form class
    * @param  string        $selector CSS selector for the root form element for this form
-   * 
+   *
    * @return sfTestFunctionalBase|sfTester
    */
   public function checkForm($form, $selector = 'form')
@@ -333,11 +336,11 @@ class sfTesterResponse extends sfTester
 
   /**
    * Tests if a cookie was set.
-   * 
+   *
    * @param  string $name
    * @param  string $value
    * @param  array  $attributes Other cookie attributes to check (expires, path, domain, etc)
-   * 
+   *
    * @return sfTestFunctionalBase|sfTester
    */
   public function setsCookie($name, $value = null, $attributes = array())

--- a/lib/user/sfUser.class.php
+++ b/lib/user/sfUser.class.php
@@ -227,6 +227,7 @@ class sfUser implements ArrayAccess
    *
    * @return Boolean true if the user attribute exists, false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($name)
   {
     return $this->hasAttribute($name);
@@ -239,6 +240,7 @@ class sfUser implements ArrayAccess
    *
    * @return mixed The user attribute if exists, null otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($name)
   {
     return $this->getAttribute($name, false);
@@ -250,6 +252,7 @@ class sfUser implements ArrayAccess
    * @param string $offset The parameter name
    * @param string $value The parameter value
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $this->setAttribute($offset, $value);
@@ -260,6 +263,7 @@ class sfUser implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     $this->getAttributeHolder()->remove($offset);

--- a/lib/util/sfBrowser.class.php
+++ b/lib/util/sfBrowser.class.php
@@ -28,10 +28,11 @@ class sfBrowser extends sfBrowserBase
    */
   protected function doCall()
   {
+    // Before getContext, it can trigger some
+    sfConfig::set('sf_test', true);
+
     // recycle our context object
     $this->context = $this->getContext(true);
-
-    sfConfig::set('sf_test', true);
 
     // we register a fake rendering filter
     sfConfig::set('sf_rendering_filter', array('sfFakeRenderingFilter', null));

--- a/lib/util/sfBrowserBase.class.php
+++ b/lib/util/sfBrowserBase.class.php
@@ -363,7 +363,10 @@ abstract class sfBrowserBase
       }
       else
       {
-        @$this->dom->loadHTML($response->getContent());
+        if ($response->getContent())
+        {
+          @$this->dom->loadHTML($response->getContent());
+        }
       }
       $this->domCssSelector = new sfDomCssSelector($this->dom);
     }
@@ -908,7 +911,7 @@ abstract class sfBrowserBase
     }
     else
     {
-      $queryString = http_build_query($arguments, null, '&');
+      $queryString = (is_array($arguments)) ? http_build_query($arguments, null, '&') : '';
       $sep = false === strpos($url, '?') ? '?' : '&';
 
       return array($url.($queryString ? $sep.$queryString : ''), 'get', array());

--- a/lib/util/sfContext.class.php
+++ b/lib/util/sfContext.class.php
@@ -508,6 +508,7 @@ class sfContext implements ArrayAccess
    *
    * @return Boolean true if the context object exists, false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($name)
   {
     return $this->has($name);
@@ -520,6 +521,7 @@ class sfContext implements ArrayAccess
    *
    * @return mixed The context object if exists, null otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($name)
   {
     return $this->get($name);
@@ -531,6 +533,7 @@ class sfContext implements ArrayAccess
    * @param string $offset Service name
    * @param mixed  $value Service
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     $this->set($offset, $value);
@@ -541,6 +544,7 @@ class sfContext implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     unset($this->factories[$offset]);

--- a/lib/util/sfDomCssSelector.class.php
+++ b/lib/util/sfDomCssSelector.class.php
@@ -563,6 +563,7 @@ class sfDomCssSelector implements Countable, Iterator
   /**
    * Reset the array to the beginning (as required for the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function rewind()
   {
     reset($this->nodes);
@@ -575,6 +576,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @return string The key
    */
+  #[\ReturnTypeWillChange]
   public function key()
   {
     return key($this->nodes);
@@ -585,6 +587,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @return mixed The escaped value
    */
+  #[\ReturnTypeWillChange]
   public function current()
   {
     return current($this->nodes);
@@ -593,6 +596,7 @@ class sfDomCssSelector implements Countable, Iterator
   /**
    * Moves to the next element (as required by the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function next()
   {
     next($this->nodes);
@@ -609,6 +613,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @return bool The validity of the current element; true if it is valid
    */
+  #[\ReturnTypeWillChange]
   public function valid()
   {
     return $this->count > 0;
@@ -619,6 +624,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @param integer The number of matching nodes
    */
+  #[\ReturnTypeWillChange]
   public function count()
   {
     return count($this->nodes);

--- a/lib/util/sfInflector.class.php
+++ b/lib/util/sfInflector.class.php
@@ -28,7 +28,7 @@ class sfInflector
   public static function camelize($lower_case_and_underscored_word)
   {
 
-    return strtr(ucwords(strtr($lower_case_and_underscored_word, array('/' => ':: ', '_' => ' ', '-' => ' '))), array(' ' => ''));
+    return strtr(ucwords(strtr((string) $lower_case_and_underscored_word, array('/' => ':: ', '_' => ' ', '-' => ' '))), array(' ' => ''));
   }
 
   /**
@@ -40,7 +40,7 @@ class sfInflector
    */
   public static function underscore($camel_cased_word)
   {
-    $tmp = $camel_cased_word;
+    $tmp = (string) $camel_cased_word;
     $tmp = str_replace('::', '/', $tmp);
     $tmp = sfToolkit::pregtr($tmp, array('/([A-Z]+)([A-Z][a-z])/' => '\\1_\\2',
                                          '/([a-z\d])([A-Z])/'     => '\\1_\\2'));

--- a/lib/util/sfNamespacedParameterHolder.class.php
+++ b/lib/util/sfNamespacedParameterHolder.class.php
@@ -366,11 +366,11 @@ class sfNamespacedParameterHolder extends sfParameterHolder
   /**
    * Serializes the current instance.
    *
-   * @return array Objects instance
+   * @return string Objects instance
    */
   public function serialize()
   {
-    return serialize(array($this->default_namespace, $this->parameters));
+    return serialize($this->__serialize());
   }
 
   /**
@@ -380,9 +380,28 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    */
   public function unserialize($serialized)
   {
-    $data = unserialize($serialized);
+    $this->__unserialize(unserialize($serialized));
+  }
 
-    $this->default_namespace = $data[0];
-    $this->parameters = $data[1];
+
+  /**
+   * Serializes the current instance for PHP 7.4+
+   *
+   * @return array
+   */
+  public function __serialize()
+  {
+    return array($this->default_namespace, $this->parameters);
+  }
+
+  /**
+   * Unserializes a sfParameterHolder instance. for PHP 7.4
+   *
+   * @param array $data
+   */
+  public function __unserialize($data)
+  {
+      $this->default_namespace = $data[0];
+      $this->parameters = $data[1];
   }
 }

--- a/lib/util/sfParameterHolder.class.php
+++ b/lib/util/sfParameterHolder.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -181,11 +181,11 @@ class sfParameterHolder implements Serializable
   /**
    * Serializes the current instance.
    *
-   * @return array Objects instance
+   * @return string Objects instance
    */
   public function serialize()
   {
-    return serialize($this->parameters);
+    return serialize($this->__serialize());
   }
 
   /**
@@ -195,6 +195,26 @@ class sfParameterHolder implements Serializable
    */
   public function unserialize($serialized)
   {
-    $this->parameters = unserialize($serialized);
+    $this->__unserialize(unserialize($serialized));
+  }
+
+  /**
+   * Serializes the current instance for PHP 7.4+
+   *
+   * @return Array
+   */
+  public function __serialize() {
+
+      return $this->parameters;
+  }
+
+  /**
+   * Unserializes a sfParameterHolder instance. for PHP 7.4
+   *
+   * @param array $data
+   */
+  public function __unserialize($data)
+  {
+    $this->parameters = $data;
   }
 }

--- a/lib/util/sfToolkit.class.php
+++ b/lib/util/sfToolkit.class.php
@@ -366,7 +366,7 @@ class sfToolkit
    */
   public static function pregtr($search, $replacePairs)
   {
-    return preg_replace(array_keys($replacePairs), array_values($replacePairs), $search);
+    return preg_replace(array_keys($replacePairs), array_values($replacePairs), (string) $search);
   }
 
   /**

--- a/lib/validator/sfValidatorError.class.php
+++ b/lib/validator/sfValidatorError.class.php
@@ -109,7 +109,7 @@ class sfValidatorError extends Exception implements Serializable
    * error messages:
    *
    * $i18n->__($error->getMessageFormat(), $error->getArguments());
-   * 
+   *
    * If no message format has been set in the validator, the exception standard
    * message is returned.
    *
@@ -140,7 +140,7 @@ class sfValidatorError extends Exception implements Serializable
    */
   public function serialize()
   {
-    return serialize(array($this->validator, $this->arguments, $this->code, $this->message));
+    return serialize($this->__serialize());
   }
 
   /**
@@ -151,6 +151,29 @@ class sfValidatorError extends Exception implements Serializable
    */
   public function unserialize($serialized)
   {
-    list($this->validator, $this->arguments, $this->code, $this->message) = unserialize($serialized);
+    $array = unserialize($serialized);
+
+    $this->__unserialize($array);
   }
+
+  /**
+   * Serializes the current instance for php 7.4+
+   *
+   * @return array
+   */
+  public function __serialize()
+  {
+    return array($this->validator, $this->arguments, $this->code, $this->message);
+  }
+
+  /**
+   * Unserializes a sfValidatorError instance for php 7.4+
+   *
+   * @param string $serialized  A serialized sfValidatorError instance
+   */
+  public function __unserialize($data)
+  {
+    list($this->validator, $this->arguments, $this->code, $this->message) = $data;
+  }
+
 }

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -176,6 +176,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return int The number of array
    */
+  #[\ReturnTypeWillChange]
   public function count()
   {
     return count($this->errors);
@@ -184,6 +185,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   /**
    * Reset the error array to the beginning (implements the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function rewind()
   {
     reset($this->errors);
@@ -196,6 +198,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return string The key
    */
+  #[\ReturnTypeWillChange]
   public function key()
   {
     return key($this->errors);
@@ -206,6 +209,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return mixed The escaped value
    */
+  #[\ReturnTypeWillChange]
   public function current()
   {
     return current($this->errors);
@@ -214,6 +218,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   /**
    * Moves to the next error (implements the Iterator interface).
    */
+  #[\ReturnTypeWillChange]
   public function next()
   {
     next($this->errors);
@@ -226,6 +231,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return boolean The validity of the current element; true if it is valid
    */
+  #[\ReturnTypeWillChange]
   public function valid()
   {
     return $this->count > 0;
@@ -238,6 +244,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return bool true if the error exists, false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($name)
   {
     return isset($this->errors[$name]);
@@ -250,6 +257,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return sfValidatorError A sfValidatorError instance
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($name)
   {
     return isset($this->errors[$name]) ? $this->errors[$name] : null;
@@ -263,6 +271,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @throws LogicException
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     throw new LogicException('Unable update an error.');
@@ -273,6 +282,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @param string $offset  (ignored)
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
   }

--- a/lib/validator/sfValidatorSchema.class.php
+++ b/lib/validator/sfValidatorSchema.class.php
@@ -309,6 +309,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    *
    * @return bool true if the schema has a field with the given name, false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($name)
   {
     return isset($this->fields[$name]);
@@ -321,6 +322,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    *
    * @return sfValidatorBase The sfValidatorBase instance associated with the given name, null if it does not exist
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($name)
   {
     return isset($this->fields[$name]) ? $this->fields[$name] : null;
@@ -332,6 +334,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    * @param string          $name       The field name
    * @param sfValidatorBase $validator  An sfValidatorBase instance
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($name, $validator)
   {
     if (!$validator instanceof sfValidatorBase)
@@ -347,6 +350,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    *
    * @param string $name
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($name)
   {
     unset($this->fields[$name]);

--- a/lib/vendor/lime/lime.php
+++ b/lib/vendor/lime/lime.php
@@ -520,11 +520,11 @@ class lime_test
   {
     $this->output->error($message, $file, $line, $traces);
 
-  	$this->results['stats']['errors'][] = array(
-  	  'message' => $message,
-  	  'file' => $file,
-  	  'line' => $line,
-  	);
+    $this->results['stats']['errors'][] = array(
+      'message' => $message,
+      'file' => $file,
+      'line' => $line,
+    );
   }
 
   protected function update_stats()
@@ -553,7 +553,8 @@ class lime_test
     $t = array_reverse($traces);
     foreach ($t as $trace)
     {
-      if (isset($trace['object']) && $this->is_test_object($trace['object']))
+      // In internal calls, like error_handle, 'file' will be missing
+      if (isset($trace['object']) && $this->is_test_object($trace['object']) && isset($trace['file']))
       {
         return array($trace['file'], $trace['line']);
       }
@@ -564,7 +565,7 @@ class lime_test
     return array($traces[$last]['file'], $traces[$last]['line']);
   }
 
-  public function handle_error($code, $message, $file, $line, $context)
+  public function handle_error($code, $message, $file, $line, $context = null)
   {
     if (!$this->options['error_reporting'] || ($code & error_reporting()) == 0)
     {
@@ -587,7 +588,11 @@ class lime_test
     $this->error($type.': '.$message, $file, $line, $trace);
   }
 
-  public function handle_exception(Throwable $exception)
+  /**
+   * @param Throwable $exception only available on php7
+   * @return bool
+   */
+  public function handle_exception($exception)
   {
     $this->error(get_class($exception).': '.$exception->getMessage(), $exception->getFile(), $exception->getLine(), $exception->getTrace());
 
@@ -1098,7 +1103,10 @@ EOF
 
             $this->output->comment(sprintf('  at %s line %s', $this->get_relative_file($testsuite['tests'][$testcase]['file']).$this->extension, $testsuite['tests'][$testcase]['line']));
             $this->output->info('  '.$testsuite['tests'][$testcase]['message']);
-            $this->output->echoln($testsuite['tests'][$testcase]['error'], null, false);
+            if (isset($testsuite['tests'][$testcase]['error']))
+            {
+              $this->output->echoln($testsuite['tests'][$testcase]['error'], null, false);
+            }
           }
         }
       }

--- a/lib/view/sfViewParameterHolder.class.php
+++ b/lib/view/sfViewParameterHolder.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -165,11 +165,11 @@ class sfViewParameterHolder extends sfParameterHolder
   /**
    * Serializes the current instance.
    *
-   * @return array Objects instance
+   * @return string Objects instance
    */
   public function serialize()
   {
-    return serialize(array($this->getAll(), $this->escapingMethod, $this->escaping));
+    return serialize($this->__serialize());
   }
 
   /**
@@ -179,8 +179,27 @@ class sfViewParameterHolder extends sfParameterHolder
    */
   public function unserialize($serialized)
   {
-    list($this->parameters, $escapingMethod, $escaping) = unserialize($serialized);
+    $this->__unserialize(unserialize($serialized));
+  }
 
+  /**
+   * Serializes the current instance for PHP 7.4+
+   *
+   * @return array
+   */
+  public function __serialize()
+  {
+    return array($this->getAll(), $this->escapingMethod, $this->escaping);
+  }
+
+  /**
+   * Unserializes a sfParameterHolder instance. for PHP 7.4
+   *
+   * @param array $data
+   */
+  public function __unserialize($data)
+  {
+    list($this->parameters, $escapingMethod, $escaping) = $data;
     $this->initialize(sfContext::hasInstance() ? sfContext::getInstance()->getEventDispatcher() : new sfEventDispatcher());
 
     $this->setEscapingMethod($escapingMethod);

--- a/lib/widget/sfWidgetFormDate.class.php
+++ b/lib/widget/sfWidgetFormDate.class.php
@@ -70,7 +70,7 @@ class sfWidgetFormDate extends sfWidgetForm
     }
     else
     {
-      $value = (string) $value == (string) (integer) $value ? (integer) $value : strtotime($value);
+      $value = (string) $value == (string) (integer) $value ? (integer) $value : strtotime( (string) $value);
       if (false === $value)
       {
         $value = $default;

--- a/lib/widget/sfWidgetFormSchema.class.php
+++ b/lib/widget/sfWidgetFormSchema.class.php
@@ -659,6 +659,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
    *
    * @return bool true if the schema has a field with the given name, false otherwise
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($name)
   {
     return isset($this->fields[$name]);
@@ -671,6 +672,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
    *
    * @return sfWidget|null The sfWidget instance associated with the given name, null if it does not exist
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($name)
   {
     return isset($this->fields[$name]) ? $this->fields[$name] : null;
@@ -684,6 +686,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
    *
    * @throws InvalidArgumentException when the field is not instance of sfWidget
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($name, $widget)
   {
     if (!$widget instanceof sfWidget)
@@ -710,6 +713,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
    *
    * @param string $name field name
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($name)
   {
     unset($this->fields[$name]);

--- a/lib/widget/sfWidgetFormSchemaDecorator.class.php
+++ b/lib/widget/sfWidgetFormSchemaDecorator.class.php
@@ -346,6 +346,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
    * @see sfWidgetFormSchema
    * @inheritdoc
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($name)
   {
     return isset($this->widget[$name]);
@@ -355,6 +356,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
    * @see sfWidgetFormSchema
    * @inheritdoc
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($name)
   {
     return $this->widget[$name];
@@ -364,6 +366,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
    * @see sfWidgetFormSchema
    * @inheritdoc
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($name, $widget)
   {
     $this->widget[$name] = $widget;
@@ -373,6 +376,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
    * @see sfWidgetFormSchema
    * @inheritdoc
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($name)
   {
     unset($this->widget[$name]);

--- a/lib/widget/sfWidgetFormTime.class.php
+++ b/lib/widget/sfWidgetFormTime.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -72,7 +72,7 @@ class sfWidgetFormTime extends sfWidgetForm
     }
     else
     {
-      $value = ctype_digit($value) ? (integer) $value : strtotime($value);
+      $value = ctype_digit( (string) $value) ? (integer) $value : strtotime( (string) $value);
       if (false === $value)
       {
         $value = $default;

--- a/lib/yaml/sfYamlInline.class.php
+++ b/lib/yaml/sfYamlInline.class.php
@@ -97,9 +97,9 @@ class sfYamlInline
         return 'true';
       case false === $value:
         return 'false';
-      case ctype_digit($value):
+      case (is_string($value) && ctype_digit($value)):
         return is_string($value) ? "'$value'" : (int) $value;
-      case is_numeric($value):
+      case is_numeric($value) && false === strpbrk($value, "\f\n\r\t\v"):
         return is_infinite($value) ? str_ireplace('INF', '.Inf', (string) $value) : (is_string($value) ? "'$value'" : $value);
       case false !== strpos($value, "\n") || false !== strpos($value, "\r"):
         return sprintf('"%s"', str_replace(array('"', "\n", "\r"), array('\\"', '\n', '\r'), $value));

--- a/lib/yaml/sfYamlParser.class.php
+++ b/lib/yaml/sfYamlParser.class.php
@@ -421,7 +421,7 @@ class sfYamlParser
     {
       $modifiers = isset($matches['modifiers']) ? $matches['modifiers'] : '';
 
-      return $this->parseFoldedScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), (int) abs($modifiers));
+      return $this->parseFoldedScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), (int) abs((int) $modifiers));
     }
     else
     {
@@ -474,7 +474,7 @@ class sfYamlParser
 
       if (preg_match('#^(?P<indent> {'.strlen($textIndent).',})(?P<text>.+)$#u', $this->currentLine, $matches))
       {
-        if (' ' == $separator && $previousIndent != $matches['indent'])
+        if (' ' == $separator && ($previousIndent && $previousIndent != $matches['indent']))
         {
           $text = substr($text, 0, -1)."\n";
         }

--- a/test/functional/fixtures/apps/frontend/config/frontendConfiguration.class.php
+++ b/test/functional/fixtures/apps/frontend/config/frontendConfiguration.class.php
@@ -11,7 +11,7 @@ class frontendConfiguration extends sfApplicationConfiguration
 
   public function filter_parameters(sfEvent $event, $parameters)
   {
-    if (false !== stripos($event->getSubject()->getHttpHeader('user-agent'), 'iPhone'))
+    if (false !== stripos((string) $event->getSubject()->getHttpHeader('user-agent'), 'iPhone'))
     {
       $event->getSubject()->setRequestFormat('iphone');
     }

--- a/test/unit/cache/sfAPCCacheTest.php
+++ b/test/unit/cache/sfAPCCacheTest.php
@@ -39,4 +39,8 @@ $t->diag('->initialize()');
 $cache = new sfAPCCache();
 $cache->initialize();
 
+// make sure expired keys are dropped
+// see https://github.com/krakjoe/apcu/issues/391
+ini_set('apc.use_request_time', 0);
+
 sfCacheDriverTests::launch($t, $cache);

--- a/test/unit/cache/sfAPCCacheTest.php
+++ b/test/unit/cache/sfAPCCacheTest.php
@@ -13,9 +13,18 @@ require_once(__DIR__.'/../../bootstrap/unit.php');
 $plan = 64;
 $t = new lime_test($plan);
 
+if (extension_loaded('apc')) {
+  $cacheClass = 'sfAPCCache';
+} elseif (extension_loaded('apcu')) {
+  $cacheClass = 'sfAPCuCache';
+} else {
+  $t->skip('APC or APCu must be loaded to run these tests', $plan);
+  return;
+}
+
 try
 {
-  new sfAPCCache();
+  new $cacheClass();
 }
 catch (sfInitializationException $e)
 {
@@ -36,7 +45,7 @@ sfConfig::set('sf_logging_enabled', false);
 
 // ->initialize()
 $t->diag('->initialize()');
-$cache = new sfAPCCache();
+$cache = new $cacheClass();
 $cache->initialize();
 
 // make sure expired keys are dropped

--- a/test/unit/cache/sfCacheDriverTests.class.php
+++ b/test/unit/cache/sfCacheDriverTests.class.php
@@ -18,7 +18,8 @@ class sfCacheDriverTests
     $t->is($cache->get('test'), $data, '->get() retrieves data form the cache');
     $t->is($cache->has('test'), true, '->has() returns true if the cache exists');
 
-    $t->ok($cache->set('test', $data, -10), '->set() takes a lifetime as its third argument');
+    $t->ok($cache->set('test', $data, 1), '->set() takes a lifetime as its third argument');
+    sleep(2);
     $t->is($cache->get('test', 'default'), 'default', '->get() returns the default value if cache has expired');
     $t->is($cache->has('test'), false, '->has() returns true if the cache exists');
 
@@ -47,21 +48,24 @@ class sfCacheDriverTests
     // ->clean()
     $t->diag('->clean()');
     $data = 'some random data to store in the cache system...';
-    $cache->set('foo', $data, -10);
+    $cache->set('foo', $data, 1);
+    sleep(2);
     $cache->set('bar', $data, 86400);
 
     $cache->clean(sfCache::OLD);
     $t->is($cache->has('foo'), false, '->clean() cleans old cache key if given the sfCache::OLD argument');
     $t->is($cache->has('bar'), true, '->clean() cleans old cache key if given the sfCache::OLD argument');
 
-    $cache->set('foo', $data, -10);
+    $cache->set('foo', $data, 1);
+    sleep(2);
     $cache->set('bar', $data, 86400);
 
     $cache->clean(sfCache::ALL);
     $t->is($cache->has('foo'), false, '->clean() cleans all cache key if given the sfCache::ALL argument');
     $t->is($cache->has('bar'), false, '->clean() cleans all cache key if given the sfCache::ALL argument');
 
-    $cache->set('foo', $data, -10);
+    $cache->set('foo', $data, 1);
+    sleep(2);
     $cache->set('bar', $data, 86400);
 
     $cache->clean();
@@ -128,7 +132,8 @@ class sfCacheDriverTests
       $t->ok($delta >= $lifetime - 1 && $delta <= $lifetime, '->getTimeout() returns the timeout time for a given cache key');
     }
 
-    $cache->set('bar', 'foo', -10);
+    $cache->set('bar', 'foo', 1);
+    sleep(2);
     $t->is($cache->getTimeout('bar'), 0, '->getTimeout() returns the timeout time for a given cache key');
 
     foreach (array(86400, 10) as $lifetime)
@@ -152,7 +157,8 @@ class sfCacheDriverTests
       $t->ok($lastModified >= time() - 1 && $lastModified <= time(), '->getLastModified() returns the last modified time for a given cache key');
     }
 
-    $cache->set('bar', 'foo', -10);
+    $cache->set('bar', 'foo', 1);
+    sleep(2);
     $t->is($cache->getLastModified('bar'), 0, '->getLastModified() returns the last modified time for a given cache key');
 
     foreach (array(86400, 10) as $lifetime)

--- a/test/unit/escaper/sfOutputEscaperObjectDecoratorTest.php
+++ b/test/unit/escaper/sfOutputEscaperObjectDecoratorTest.php
@@ -74,6 +74,7 @@ class Foo
 
 class FooCountable implements Countable
 {
+  #[\ReturnTypeWillChange]
   public function count()
   {
     return 2;

--- a/test/unit/log/sfFileLoggerTest.php
+++ b/test/unit/log/sfFileLoggerTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -61,7 +61,7 @@ $t->diag('option: format');
 unlink($file);
 $logger = new TestLogger($dispatcher, array('file' => $file));
 $logger->log('foo');
-$t->is(file_get_contents($file), strftime($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
+$t->is(file_get_contents($file), TestLogger::strftime($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
 
 unlink($file);
 $logger = new TestLogger($dispatcher, array('file' => $file, 'format' => '%message%'));
@@ -73,14 +73,14 @@ $t->diag('option: time_format');
 unlink($file);
 $logger = new TestLogger($dispatcher, array('file' => $file, 'time_format' => '%Y %m %d'));
 $logger->log('foo');
-$t->is(file_get_contents($file), strftime($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
+$t->is(file_get_contents($file), TestLogger::strftime($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
 
 // option: type
 $t->diag('option: type');
 unlink($file);
 $logger = new TestLogger($dispatcher, array('file' => $file, 'type' => 'foo'));
 $logger->log('foo');
-$t->is(file_get_contents($file), strftime($logger->getTimeFormat()).' foo [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
+$t->is(file_get_contents($file), TestLogger::strftime($logger->getTimeFormat()).' foo [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
 
 // ->shutdown()
 $t->diag('->shutdown()');

--- a/test/unit/plugin/sfPearRestTest.class.php
+++ b/test/unit/plugin/sfPearRestTest.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,7 +21,7 @@ class sfPearRestTest extends sfPearRest
   /**
    * @see PEAR_REST::downloadHttp()
    */
-  public function downloadHttp($url, $lastmodified = null, $accept = false)
+  public function downloadHttp($url, $lastmodified = null, $accept = false, $channel = false)
   {
     try
     {

--- a/test/unit/response/sfResponseTest.php
+++ b/test/unit/response/sfResponseTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -14,6 +14,8 @@ class myResponse extends sfResponse
 {
   function serialize() {}
   function unserialize($serialized) {}
+  function __serialize() {}
+  function __unserialize($data) {}
 }
 
 class fakeResponse

--- a/test/unit/response/sfWebResponseTest.php
+++ b/test/unit/response/sfWebResponseTest.php
@@ -132,7 +132,7 @@ $t->is($response->getContentType(), $response->getHttpHeader('content-type'), '-
 
 $response->setContentType('text/xml');
 $response->setContentType('text/html');
-$t->is(count($response->getHttpHeader('content-type')), 1, '->setContentType() overrides previous content type if replace is true');
+$t->is($response->getHttpHeader('content-type'), 'text/html; charset=ISO-8859-1', '->setContentType() overrides previous content type if replace is true');
 
 // ->getTitle() ->setTitle() ->prependTitle
 $t->diag('->getTitle() ->setTitle() ->prependTitle()');

--- a/test/unit/response/sfWebResponseTest.php
+++ b/test/unit/response/sfWebResponseTest.php
@@ -288,7 +288,7 @@ $t->is($response->clearJavascripts(), array(), '->clearJavascripts() removes all
 // ->setCookie() ->getCookies()
 $t->diag('->setCookie() ->getCookies()');
 $response->setCookie('foo', 'bar');
-$t->is($response->getCookies(), array('foo' => array('name' => 'foo', 'value' => 'bar', 'expire' => null, 'path' => '/', 'domain' => '', 'secure' => false, 'httpOnly' => false)), '->setCookie() adds a cookie for the response');
+$t->is($response->getCookies(), array('foo' => array('name' => 'foo', 'value' => 'bar', 'expire' => null, 'path' => '/', 'domain' => '', 'secure' => false, 'httpOnly' => false, 'samesite' => '')), '->setCookie() adds a cookie for the response');
 
 // ->setHeaderOnly() ->getHeaderOnly()
 $t->diag('->setHeaderOnly() ->isHeaderOnly()');

--- a/test/unit/storage/sfCacheSessionStorageTest.php
+++ b/test/unit/storage/sfCacheSessionStorageTest.php
@@ -19,14 +19,13 @@ require_once($_test_dir.'/../lib/vendor/lime/lime.php');
 
 sfConfig::set('sf_symfony_lib_dir', realpath($_test_dir.'/../lib'));
 
+// setup cache
+$temp = tempnam('/tmp/cache_dir', 'tmp');
+unlink($temp);
+mkdir($temp);
+
 $plan = 8;
 $t = new lime_test($plan);
-
-if (!ini_get('apc.enable_cli'))
-{
-  $t->skip('APC must be enable on CLI to run these tests', $plan);
-  return;
-}
 
 // initialize the storage
 try
@@ -40,7 +39,7 @@ catch (InvalidArgumentException $e)
 }
 
 
-$storage = new sfCacheSessionStorage(array('cache' => array('class' => 'sfAPCCache', 'param' => array())));
+$storage = new sfCacheSessionStorage(array('cache' => array('class' => 'sfFileCache', 'param' => array('cache_dir' => $temp))));
 $t->ok($storage instanceof sfStorage, '->__construct() is an instance of sfStorage');
 
 $storage->write('test', 123);
@@ -66,3 +65,7 @@ $t->is($storage->read($key), null, '->remove() removes data from the storage');
 
 // shutdown the storage
 $storage->shutdown();
+
+// clean up cache
+sfToolkit::clearDirectory($temp);
+rmdir($temp);

--- a/test/unit/storage/sfCacheSessionStorageTest.php
+++ b/test/unit/storage/sfCacheSessionStorageTest.php
@@ -12,6 +12,8 @@ $app = 'frontend';
 
 require_once(__DIR__.'/../../bootstrap/functional.php');
 
+ob_start();
+
 $_test_dir = realpath(__DIR__.'/../../');
 require_once($_test_dir.'/../lib/vendor/lime/lime.php');
 

--- a/test/unit/storage/sfSessionStorageTest.php
+++ b/test/unit/storage/sfSessionStorageTest.php
@@ -26,6 +26,7 @@ try
 {
   $storage = new sfSessionStorage();
   $t->pass('->__construct() does not throw an exception when not provided with options');
+  $storage->shutdown();
 }
 catch (InvalidArgumentException $e)
 {

--- a/test/unit/validator/sfValidatorErrorSchemaTest.php
+++ b/test/unit/validator/sfValidatorErrorSchemaTest.php
@@ -187,6 +187,16 @@ class NotSerializable implements Serializable
   {
     throw new Exception('Not serializable');
   }
+
+  public function __serialize()
+  {
+    throw new Exception('Not serializable');
+  }
+
+  public function __unserialize($data)
+  {
+    throw new Exception('Not serializable');
+  }
 }
 
 function will_crash($a)

--- a/test/unit/validator/sfValidatorErrorTest.php
+++ b/test/unit/validator/sfValidatorErrorTest.php
@@ -65,6 +65,16 @@ class NotSerializable implements Serializable
   {
     throw new Exception('Not serializable');
   }
+
+  public function __serialize()
+  {
+    throw new Exception('Not serializable');
+  }
+
+  public function __unserialize($data)
+  {
+    throw new Exception('Not serializable');
+  }
 }
 
 function will_crash($a)

--- a/test/unit/validator/sfValidatorFileTest.php
+++ b/test/unit/validator/sfValidatorFileTest.php
@@ -105,7 +105,7 @@ $t->diag('->guessFromFileBinary()');
 $v = new testValidatorFile();
 $t->is($v->guessFromFileBinary($tmpDir.'/test.txt'), 'text/plain', '->guessFromFileBinary() guesses the type of a given file');
 $t->is($v->guessFromFileBinary($tmpDir.'/foo.txt'), null, '->guessFromFileBinary() returns null if the file type is not guessable');
-$t->is($v->guessFromFileBinary('/bin/ls'), (PHP_OS != 'Darwin') ? 'application/x-executable' : 'application/octet-stream', '->guessFromFileBinary() returns correct type if file is guessable');
+$t->like($v->guessFromFileBinary('/bin/ls'), (PHP_OS != 'Darwin') ? '/^application\/x-(executable|sharedlib)$/' : '/^application/octet-stream$/', '->guessFromFileBinary() returns correct type if file is guessable');
 $t->is($v->guessFromFileBinary('-test'), null, '->guessFromFileBinary() returns null if file path has leading dash');
 
 // ->getMimeType()


### PR DESCRIPTION
The APC support has been broken for a while now (see [here](https://github.com/FriendsOfSymfony1/symfony1/issues/125) and [here](https://github.com/FriendsOfSymfony1/symfony1/issues/48)) but since `sfAPCCacheTest` is often skipped, it's been overlooked.

The issue is that APC has been dropped in more recent versions of PHP and the user cache part of it is now provided by APCu. However, the functions have been changed (eg: `apc_get()` to `apcu_get()`, and while there was a [compatibility layer](https://github.com/krakjoe/apcu-bc) for a while it doesn't seem to be maintained anymore. These days one needs to use APC or APCu, often as a requirement by the PHP being used. In other words, `sfAPCCache`, as is, no longer works in recent versions of PHP where only APCu is available.

This PR fixes the issues with APC inconsistencies when using with negative TTLs, and also adds a new sfAPCuCache that is a drop-in replacement for sfAPCCache. It's pretty minor changes from sfAPCCache, and while it is duplicated code, it's likely one of the cleanest ways to address this without overcomplicating things. `sfAPCCacheTest` loads the right one according to which extension is present (apc vs apcu).

Lastly, not sure if we should now drop the line bellow allow `travis.yml` to run the tests with APC (&APCu) again. 

https://github.com/FriendsOfSymfony1/symfony1/blob/6f521e9ef9e800c655313a5f21ac3f55552fbcf4/.travis.yml#L36
