### PR TITLE
Fix APC tests and add APCu support

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -3,9 +3,3 @@
 #
 # Copy to `.env` in order to use it.
 #
-
-# APC test are disabled.
-#
-# To enable them in order to provide a fix, set to "on".
-#
-APC_ENABLE_CLI=off

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,6 +39,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          extensions: apcu
+          ini-values: apc.enable_cli=1
 
       - name: Get composer cache directory
         id: composer-cache

--- a/data/bin/check_configuration.php
+++ b/data/bin/check_configuration.php
@@ -77,7 +77,7 @@ check(function_exists('utf8_decode'), 'The utf8_decode() is available', 'Install
 check(function_exists('posix_isatty'), 'The posix_isatty() is available', 'Install and enable the php_posix extension (used to colorized the CLI output)', false);
 
 $accelerator =
-  (function_exists('apc_store') && ini_get('apc.enabled'))
+  ((function_exists('apc_store') || function_exists('apcu_store')) && ini_get('apc.enabled'))
   || function_exists('eaccelerator_put') && ini_get('eaccelerator.enable')
   || function_exists('xcache_set');
 check($accelerator, 'A PHP accelerator is installed', 'Install a PHP accelerator like APC (highly recommended)', false);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       args:
         PHP_TAG: '7.0-cli-jessie'
         MEMCACHE_VERSION: '4.0.5.2'
-        APCU_VERSION: ''
+        APCU_VERSION: '5.1.23'
 
   php71:
     <<: *services_php54
@@ -103,7 +103,7 @@ services:
       args:
         PHP_TAG: '7.1-cli-jessie'
         MEMCACHE_VERSION: '4.0.5.2'
-        APCU_VERSION: ''
+        APCU_VERSION: '5.1.23'
 
 
   php72:
@@ -113,7 +113,7 @@ services:
       args:
         PHP_VERSION: '7.2'
         MEMCACHE_VERSION: '4.0.5.2'
-        APCU_VERSION: ''
+        APCU_VERSION: '5.1.23'
 
 
   php73:
@@ -123,7 +123,7 @@ services:
       args:
         PHP_VERSION: '7.3'
         MEMCACHE_VERSION: '4.0.5.2'
-        APCU_VERSION: ''
+        APCU_VERSION: '5.1.23'
 
 
   php74:
@@ -133,7 +133,7 @@ services:
       args:
         PHP_VERSION: '7.4'
         MEMCACHE_VERSION: '4.0.5.2'
-        APCU_VERSION: ''
+        APCU_VERSION: '5.1.23'
 
 
   php80:
@@ -143,7 +143,7 @@ services:
       args:
         PHP_VERSION: '8.0'
         MEMCACHE_VERSION: '8.0'
-        APCU_VERSION: ''
+        APCU_VERSION: '5.1.23'
 
 
   php81:
@@ -153,7 +153,7 @@ services:
       args:
         PHP_VERSION: '8.1'
         MEMCACHE_VERSION: '8.0'
-        APCU_VERSION: ''
+        APCU_VERSION: '5.1.23'
 
   php82:
     <<: *services_php54
@@ -162,7 +162,7 @@ services:
       args:
         PHP_VERSION: '8.2'
         MEMCACHE_VERSION: '8.0'
-        APCU_VERSION: ''
+        APCU_VERSION: '5.1.23'
 
   php83:
     <<: *services_php54
@@ -171,7 +171,7 @@ services:
       args:
         PHP_VERSION: '8.3'
         MEMCACHE_VERSION: '8.0'
-        APCU_VERSION: ''
+        APCU_VERSION: '5.1.23'
 
 
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
           echo 'short_open_tag = off'
           echo 'magic_quotes_gpc = off'
           echo 'date.timezone = "UTC"'
-          echo 'apc.enable_cli = ${APC_ENABLE_CLI-off}'
+          echo 'apc.enable_cli = on'
           echo 'apc.use_request_time = 0'
         } | tee -a /usr/local/lib/php.ini
 
@@ -60,7 +60,7 @@ services:
           echo 'short_open_tag = off'
           echo 'magic_quotes_gpc = off'
           echo 'date.timezone = "UTC"'
-          echo 'apc.enable_cli = ${APC_ENABLE_CLI-off}'
+          echo 'apc.enable_cli = on'
           echo 'apc.use_request_time = 0'
         } | tee -a /usr/local/etc/php/php.ini
 

--- a/lib/autoload/sfCoreAutoload.class.php
+++ b/lib/autoload/sfCoreAutoload.class.php
@@ -44,6 +44,7 @@ class sfCoreAutoload
         'sfcoreautoload' => 'autoload/sfCoreAutoload.class.php',
         'sfsimpleautoload' => 'autoload/sfSimpleAutoload.class.php',
         'sfapccache' => 'cache/sfAPCCache.class.php',
+        'sfapcucache' => 'cache/sfAPCuCache.class.php',
         'sfcache' => 'cache/sfCache.class.php',
         'sfeacceleratorcache' => 'cache/sfEAcceleratorCache.class.php',
         'sffilecache' => 'cache/sfFileCache.class.php',

--- a/lib/cache/sfAPCuCache.class.php
+++ b/lib/cache/sfAPCuCache.class.php
@@ -1,0 +1,195 @@
+<?php
+
+/*
+ * This file is part of the symfony package.
+ * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Cache class that stores cached content in APCu.
+ *
+ * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
+ * @author     Paulo M
+ *
+ * @version    SVN: $Id$
+ */
+class sfAPCuCache extends sfCache
+{
+    protected $enabled;
+
+    /**
+     * Initializes this sfCache instance.
+     *
+     * Available options:
+     *
+     * * see sfCache for options available for all drivers
+     *
+     * @see sfCache
+     */
+    public function initialize($options = array())
+    {
+        parent::initialize($options);
+
+        $this->enabled = function_exists('apcu_store') && ini_get('apc.enabled');
+    }
+
+    /**
+     * @see sfCache
+     *
+     * @param mixed|null $default
+     */
+    public function get($key, $default = null)
+    {
+        if (!$this->enabled) {
+            return $default;
+        }
+
+        $value = $this->fetch($this->getOption('prefix').$key, $has);
+
+        return $has ? $value : $default;
+    }
+
+    /**
+     * @see sfCache
+     */
+    public function has($key)
+    {
+        if (!$this->enabled) {
+            return false;
+        }
+
+        $this->fetch($this->getOption('prefix').$key, $has);
+
+        return $has;
+    }
+
+    /**
+     * @see sfCache
+     *
+     * @param mixed|null $lifetime
+     */
+    public function set($key, $data, $lifetime = null)
+    {
+        if (!$this->enabled) {
+            return true;
+        }
+
+        return apcu_store($this->getOption('prefix').$key, $data, $this->getLifetime($lifetime));
+    }
+
+    /**
+     * @see sfCache
+     */
+    public function remove($key)
+    {
+        if (!$this->enabled) {
+            return true;
+        }
+
+        return apcu_delete($this->getOption('prefix').$key);
+    }
+
+    /**
+     * @see sfCache
+     */
+    public function clean($mode = sfCache::ALL)
+    {
+        if (!$this->enabled) {
+            return true;
+        }
+
+        if (sfCache::ALL === $mode) {
+            return apcu_clear_cache();
+        }
+    }
+
+    /**
+     * @see sfCache
+     */
+    public function getLastModified($key)
+    {
+        if ($info = $this->getCacheInfo($key)) {
+            return $info['creation_time'] + $info['ttl'] > time() ? $info['mtime'] : 0;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @see sfCache
+     */
+    public function getTimeout($key)
+    {
+        if ($info = $this->getCacheInfo($key)) {
+            return $info['creation_time'] + $info['ttl'] > time() ? $info['creation_time'] + $info['ttl'] : 0;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @see sfCache
+     */
+    public function removePattern($pattern)
+    {
+        if (!$this->enabled) {
+            return true;
+        }
+
+        $infos = apcu_cache_info();
+        if (!is_array($infos['cache_list'])) {
+            return;
+        }
+
+        $regexp = self::patternToRegexp($this->getOption('prefix').$pattern);
+
+        foreach ($infos['cache_list'] as $info) {
+            if (preg_match($regexp, $info['info'])) {
+                apcu_delete($info['info']);
+            }
+        }
+    }
+
+    /**
+     * Gets the cache info.
+     *
+     * @param string $key The cache key
+     *
+     * @return string
+     */
+    protected function getCacheInfo($key)
+    {
+        if (!$this->enabled) {
+            return false;
+        }
+
+        $infos = apcu_cache_info();
+
+        if (is_array($infos['cache_list'])) {
+            foreach ($infos['cache_list'] as $info) {
+                if ($this->getOption('prefix').$key == $info['info']) {
+                    return $info;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function fetch($key, &$success)
+    {
+        $has = null;
+        $value = apcu_fetch($key, $has);
+        // the second argument was added in APC 3.0.17. If it is still null we fall back to the value returned
+        if (null !== $has) {
+            $success = $has;
+        } else {
+            $success = false !== $value;
+        }
+
+        return $value;
+    }
+}

--- a/test/unit/cache/sfAPCCacheTest.php
+++ b/test/unit/cache/sfAPCCacheTest.php
@@ -37,4 +37,8 @@ $t->diag('->initialize()');
 $cache = new sfAPCCache();
 $cache->initialize();
 
+// make sure expired keys are dropped
+// see https://github.com/krakjoe/apcu/issues/391
+ini_set('apc.use_request_time', 0);
+
 sfCacheDriverTests::launch($t, $cache);

--- a/test/unit/cache/sfAPCCacheTest.php
+++ b/test/unit/cache/sfAPCCacheTest.php
@@ -13,8 +13,23 @@ require_once __DIR__.'/../../bootstrap/unit.php';
 $plan = 64;
 $t = new lime_test($plan);
 
+if (extension_loaded('apc')) {
+    $cacheClass = 'sfAPCCache';
+} elseif (extension_loaded('apcu')) {
+    if ('5.1.22' === phpversion('apcu')) {
+        $t->skip('APCu 5.1.22 has a regression and shouldn\'t be used', $plan);
+
+        return;
+    }
+    $cacheClass = 'sfAPCuCache';
+} else {
+    $t->skip('APC or APCu must be loaded to run these tests', $plan);
+
+    return;
+}
+
 try {
-    new sfAPCCache();
+    new $cacheClass();
 } catch (sfInitializationException $e) {
     $t->skip($e->getMessage(), $plan);
 
@@ -34,7 +49,7 @@ sfConfig::set('sf_logging_enabled', false);
 
 // ->initialize()
 $t->diag('->initialize()');
-$cache = new sfAPCCache();
+$cache = new $cacheClass();
 $cache->initialize();
 
 // make sure expired keys are dropped

--- a/test/unit/cache/sfCacheDriverTests.class.php
+++ b/test/unit/cache/sfCacheDriverTests.class.php
@@ -18,7 +18,8 @@ class sfCacheDriverTests
         $t->is($cache->get('test'), $data, '->get() retrieves data form the cache');
         $t->is($cache->has('test'), true, '->has() returns true if the cache exists');
 
-        $t->ok($cache->set('test', $data, -10), '->set() takes a lifetime as its third argument');
+        $t->ok($cache->set('test', $data, 1), '->set() takes a lifetime as its third argument');
+        sleep(2);
         $t->is($cache->get('test', 'default'), 'default', '->get() returns the default value if cache has expired');
         $t->is($cache->has('test'), false, '->has() returns true if the cache exists');
 
@@ -47,21 +48,24 @@ class sfCacheDriverTests
         // ->clean()
         $t->diag('->clean()');
         $data = 'some random data to store in the cache system...';
-        $cache->set('foo', $data, -10);
+        $cache->set('foo', $data, 1);
         $cache->set('bar', $data, 86400);
+        sleep(2);
 
         $cache->clean(sfCache::OLD);
         $t->is($cache->has('foo'), false, '->clean() cleans old cache key if given the sfCache::OLD argument');
         $t->is($cache->has('bar'), true, '->clean() cleans old cache key if given the sfCache::OLD argument');
 
-        $cache->set('foo', $data, -10);
+        $cache->set('foo', $data, -1);
+        sleep(2);
         $cache->set('bar', $data, 86400);
 
         $cache->clean(sfCache::ALL);
         $t->is($cache->has('foo'), false, '->clean() cleans all cache key if given the sfCache::ALL argument');
         $t->is($cache->has('bar'), false, '->clean() cleans all cache key if given the sfCache::ALL argument');
 
-        $cache->set('foo', $data, -10);
+        $cache->set('foo', $data, 1);
+        sleep(2);
         $cache->set('bar', $data, 86400);
 
         $cache->clean();
@@ -126,7 +130,8 @@ class sfCacheDriverTests
             $t->ok($delta >= $lifetime - 1 && $delta <= $lifetime, '->getTimeout() returns the timeout time for a given cache key');
         }
 
-        $cache->set('bar', 'foo', -10);
+        $cache->set('bar', 'foo', 1);
+        sleep(2);
         $t->is($cache->getTimeout('bar'), 0, '->getTimeout() returns the timeout time for a given cache key');
 
         foreach (array(86400, 10) as $lifetime) {
@@ -148,7 +153,8 @@ class sfCacheDriverTests
             $t->ok($lastModified >= time() - 1 && $lastModified <= time(), '->getLastModified() returns the last modified time for a given cache key');
         }
 
-        $cache->set('bar', 'foo', -10);
+        $cache->set('bar', 'foo', 1);
+        sleep(2);
         $t->is($cache->getLastModified('bar'), 0, '->getLastModified() returns the last modified time for a given cache key');
 
         foreach (array(86400, 10) as $lifetime) {

--- a/test/unit/storage/sfCacheSessionStorageTest.php
+++ b/test/unit/storage/sfCacheSessionStorageTest.php
@@ -20,14 +20,13 @@ require_once $_test_dir.'/../lib/vendor/lime/lime.php';
 
 sfConfig::set('sf_symfony_lib_dir', realpath($_test_dir.'/../lib'));
 
+// setup cache
+$temp = tempnam('/tmp/cache_dir', 'tmp');
+unlink($temp);
+mkdir($temp);
+
 $plan = 8;
 $t = new lime_test($plan);
-
-if (!ini_get('apc.enable_cli')) {
-    $t->skip('APC must be enable on CLI to run these tests', $plan);
-
-    return;
-}
 
 // initialize the storage
 try {
@@ -37,7 +36,7 @@ try {
     $t->pass('->__construct() throws an exception when not provided a cache option');
 }
 
-$storage = new sfCacheSessionStorage(array('cache' => array('class' => 'sfAPCCache', 'param' => array())));
+$storage = new sfCacheSessionStorage(array('cache' => array('class' => 'sfFileCache', 'param' => array('cache_dir' => $temp))));
 $t->ok($storage instanceof sfStorage, '->__construct() is an instance of sfStorage');
 
 $storage->write('test', 123);
@@ -63,3 +62,7 @@ $t->is($storage->read($key), null, '->remove() removes data from the storage');
 
 // shutdown the storage
 $storage->shutdown();
+
+// clean up cache
+sfToolkit::clearDirectory($temp);
+rmdir($temp);

--- a/test/unit/storage/sfCacheSessionStorageTest.php
+++ b/test/unit/storage/sfCacheSessionStorageTest.php
@@ -12,6 +12,8 @@ $app = 'frontend';
 
 require_once __DIR__.'/../../bootstrap/functional.php';
 
+ob_start();
+
 $_test_dir = realpath(__DIR__.'/../../');
 
 require_once $_test_dir.'/../lib/vendor/lime/lime.php';


### PR DESCRIPTION
This replaces #263.

The APC support has been broken for a while now (see [here](https://github.com/FriendsOfSymfony1/symfony1/issues/125) and [here](https://github.com/FriendsOfSymfony1/symfony1/issues/48)) but since `sfAPCCacheTest` is often skipped, it's been overlooked.

The issue is that APC has been dropped in more recent versions of PHP and the user cache part of it is now provided by APCu. While there was a [compatibility layer](https://github.com/krakjoe/apcu-bc) it doesn't seem to be maintained anymore, so the functions now have different names (eg: `apc_get()` to `apcu_get()`. These days, according to the PHP version use, one needs to use either APC or APCu. In other words, `sfAPCCache`, as is, no longer works in recent versions of PHP where only APCu is available.

This PR fixes some APC/APCu inconsistencies when using negative TTLs in the tests, and also adds a new sfAPCuCache that is a drop-in replacement for sfAPCCache. It's pretty minor changes from sfAPCCache, and while it is duplicated code, I think it's one of cleanest ways to address this without overcomplicating things. `sfAPCCacheTest` loads the right one according to which extension is present (apc vs apcu).

Lastly, not sure if we should now drop the line bellow allow `travis.yml` to run the tests with APC (&APCu) again. 

https://github.com/FriendsOfSymfony1/symfony1/blob/6f521e9ef9e800c655313a5f21ac3f55552fbcf4/.travis.yml#L36
