### PR TITLE
set symfony version to 1.5.15-dev

### DIFF
--- a/lib/autoload/sfCoreAutoload.class.php
+++ b/lib/autoload/sfCoreAutoload.class.php
@@ -11,7 +11,7 @@
 /**
  * The current symfony version.
  */
-define('SYMFONY_VERSION', '1.5.14-dev');
+define('SYMFONY_VERSION', '1.5.15-dev');
 
 /**
  * sfCoreAutoload class.


### PR DESCRIPTION
Setting the constant SYMFONY_VERSION to the next version. Before the next release, we should change it to 1.5.15