### PR TITLE
Adapt to Swiftmailer 5 and Swiftmailer 6 version of class Swift_ConfigurableSpool

### DIFF
--- a/lib/plugins/sfDoctrinePlugin/lib/mailer/Swift_DoctrineSpool.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/mailer/Swift_DoctrineSpool.class.php
@@ -23,7 +23,7 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id$
  */
-class Swift_DoctrineSpool extends Swift_ConfigurableSpool
+class Swift_DoctrineSpool extends Swift_DoctrineSpoolAdapter
 {
   protected
     $model = null,
@@ -71,9 +71,9 @@ class Swift_DoctrineSpool extends Swift_ConfigurableSpool
   /**
    * Stores a message in the queue.
    *
-   * @param Swift_Mime_Message $message The message to store
+   * @param $message The message to store
    */
-  public function queueMessage(Swift_Mime_Message $message)
+  protected function internalQueueMessage($message)
   {
     $object = new $this->model;
 
@@ -84,7 +84,7 @@ class Swift_DoctrineSpool extends Swift_ConfigurableSpool
 
     $object->{$this->column} = serialize($message);
     $object->save();
-    
+
     $object->free(true);
   }
 

--- a/lib/plugins/sfDoctrinePlugin/lib/mailer/Swift_DoctrineSpoolAdapter.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/mailer/Swift_DoctrineSpoolAdapter.php
@@ -1,0 +1,21 @@
+<?php
+
+// Defining a base class for Swift_DoctrineSpool to handle both, Swiftmailer 5 and Swiftmailer 6,
+// as we are implementing a base class from the package, we can't simply remove the type hint.
+if(class_exists('Swift') && version_compare(Swift::VERSION, '6.0.0') >= 0) {
+  abstract class Swift_DoctrineSpoolAdapter extends Swift_DoctrineSpoolBase
+  {
+    public function queueMessage(Swift_Mime_SimpleMessage $message)
+    {
+      $this->internalQueueMessage($message);
+    }
+  }
+} else {
+  abstract class Swift_DoctrineSpoolAdapter extends Swift_DoctrineSpoolBase
+  {
+    public function queueMessage(Swift_Mime_Message $message)
+    {
+      $this->internalQueueMessage($message);
+    }
+  }
+}

--- a/lib/plugins/sfDoctrinePlugin/lib/mailer/Swift_DoctrineSpoolBase.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/mailer/Swift_DoctrineSpoolBase.php
@@ -1,0 +1,6 @@
+<?php
+
+abstract class Swift_DoctrineSpoolBase extends Swift_ConfigurableSpool
+{
+  protected abstract function internalQueueMessage($message);
+}


### PR DESCRIPTION
@thePanz as promised, here is a possible solution of the swiftmailer issue. What do you think?

Btw. as the swiftmailer package is discontinued but needs a small adjustment for php 8.2: Should we clone the official repo in fos1 as well or try to adapt to symfony/mailer?