### PR TITLE
Fix PHP8.1 sfForm - Unsupported operand types: array + null on sfForm

### DIFF
--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -47,7 +47,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
     protected $isBound = false;
     protected $taintedValues = array();
     protected $taintedFiles = array();
-    protected $values;
+    protected $values = array();
     protected $defaults = array();
     protected $fieldNames = array();
     protected $options = array();


### PR DESCRIPTION
Fix PHP8.1 sfForm - Unsupported operand types: array + null on sfForm::updateValues()

Avoid error :
Fatal error: Uncaught TypeError: Unsupported operand types: array + null in lib\form\sfForm.class.php:319

Step to reproduce :
$form = new sfForm();
$form->updateValues(array('foo' => 'value'));

PHP 5.3 coding style

May use sfForm::getValues(), but as sfForm::updateValues() is a hack, it could be used before bind ($this->isBound = true);