### PR TITLE
Apply explicit string casts for strtolower() and urlencode() functions

### DIFF
--- a/lib/action/sfAction.class.php
+++ b/lib/action/sfAction.class.php
@@ -404,7 +404,7 @@ abstract class sfAction extends sfComponent
    */
   public function getSecurityValue($name, $default = null)
   {
-    $actionName = strtolower($this->getActionName());
+    $actionName = strtolower((string) $this->getActionName());
 
     if (isset($this->security[$actionName][$name]))
     {
@@ -517,7 +517,7 @@ abstract class sfAction extends sfComponent
    */
   public function setViewClass($class)
   {
-    sfConfig::set('mod_'.strtolower($this->getModuleName()).'_view_class', $class);
+    sfConfig::set('mod_'.strtolower((string) $this->getModuleName()).'_view_class', $class);
   }
 
   /**

--- a/lib/autoload/sfAutoload.class.php
+++ b/lib/autoload/sfAutoload.class.php
@@ -83,7 +83,7 @@ class sfAutoload
    */
   public function setClassPath($class, $path)
   {
-    $class = strtolower($class);
+    $class = strtolower((string) $class);
 
     $this->overriden[$class] = $path;
 
@@ -99,7 +99,7 @@ class sfAutoload
    */
   public function getClassPath($class)
   {
-    $class = strtolower($class);
+    $class = strtolower((string) $class);
 
     return isset($this->classes[$class]) ? $this->classes[$class] : null;
   }
@@ -185,7 +185,7 @@ class sfAutoload
    */
   public function loadClass($class)
   {
-    $class = strtolower($class);
+    $class = strtolower((string) $class);
 
     // class already exists
     if (class_exists($class, false) || interface_exists($class, false) || (function_exists('trait_exists') && trait_exists($class, false)))

--- a/lib/autoload/sfCoreAutoload.class.php
+++ b/lib/autoload/sfCoreAutoload.class.php
@@ -116,7 +116,7 @@ class sfCoreAutoload
    */
   public function getClassPath($class)
   {
-    $class = strtolower($class);
+    $class = strtolower((string) $class);
 
     if (!isset($this->classes[$class]))
     {
@@ -169,7 +169,7 @@ class sfCoreAutoload
           || false !== stripos($contents, 'interface '.$class)
           || false !== stripos($contents, 'trait '.$class))
       {
-        $classes .= sprintf("    '%s' => '%s',\n", strtolower($class), substr(str_replace($libDir, '', $file), 1));
+        $classes .= sprintf("    '%s' => '%s',\n", strtolower((string) $class), substr(str_replace($libDir, '', $file), 1));
       }
     }
 

--- a/lib/autoload/sfSimpleAutoload.class.php
+++ b/lib/autoload/sfSimpleAutoload.class.php
@@ -109,7 +109,7 @@ class sfSimpleAutoload
    */
   public function autoload($class)
   {
-    $class = strtolower($class);
+    $class = strtolower((string) $class);
 
     // class already exists
     if (class_exists($class, false) || interface_exists($class, false))
@@ -291,7 +291,7 @@ class sfSimpleAutoload
     preg_match_all('~^\s*(?:abstract\s+|final\s+)?(?:class|interface|trait)\s+(\w+)~mi', file_get_contents($file), $classes);
     foreach ($classes[1] as $class)
     {
-      $this->classes[strtolower($class)] = $file;
+      $this->classes[strtolower((string) $class)] = $file;
     }
   }
 
@@ -303,7 +303,7 @@ class sfSimpleAutoload
    */
   public function setClassPath($class, $path)
   {
-    $class = strtolower($class);
+    $class = strtolower((string) $class);
 
     $this->overriden[$class] = $path;
 
@@ -319,7 +319,7 @@ class sfSimpleAutoload
    */
   public function getClassPath($class)
   {
-    $class = strtolower($class);
+    $class = strtolower((string) $class);
 
     return isset($this->classes[$class]) ? $this->classes[$class] : null;
   }

--- a/lib/config/sfAutoloadConfigHandler.class.php
+++ b/lib/config/sfAutoloadConfigHandler.class.php
@@ -82,7 +82,7 @@ class sfAutoloadConfigHandler extends sfYamlConfigHandler
         // file mapping
         foreach ($entry['files'] as $class => $file)
         {
-          $mapping[strtolower($class)] = $file;
+          $mapping[strtolower((string) $class)] = $file;
         }
       }
       else
@@ -140,7 +140,7 @@ class sfAutoloadConfigHandler extends sfYamlConfigHandler
         }
       }
 
-      $mapping[$localPrefix.strtolower($class)] = $file;
+      $mapping[$localPrefix.strtolower((string) $class)] = $file;
     }
 
     return $mapping;

--- a/lib/config/sfDefineEnvironmentConfigHandler.class.php
+++ b/lib/config/sfDefineEnvironmentConfigHandler.class.php
@@ -30,14 +30,14 @@ class sfDefineEnvironmentConfigHandler extends sfYamlConfigHandler
   public function execute($configFiles)
   {
     // get our prefix
-    $prefix = strtolower($this->getParameterHolder()->get('prefix', ''));
+    $prefix = strtolower((string) $this->getParameterHolder()->get('prefix', ''));
 
     // add module prefix if needed
     if ($this->getParameterHolder()->get('module', false))
     {
       $wildcardValues = $this->getParameterHolder()->get('wildcardValues');
       // either the module name is in wildcard values, or it needs to be inserted on runtime
-      $moduleName = $wildcardValues ? strtolower($wildcardValues[0]) : "'.strtolower(\$moduleName).'";
+      $moduleName = $wildcardValues ? strtolower((string) $wildcardValues[0]) : "'.strtolower(\$moduleName).'";
       $prefix .= $moduleName."_";
     }
 
@@ -82,7 +82,7 @@ class sfDefineEnvironmentConfigHandler extends sfYamlConfigHandler
   {
     if (!is_array($keys))
     {
-      list($key, $value) = $this->fixCategoryValue($prefix.strtolower($category), '', $keys);
+      list($key, $value) = $this->fixCategoryValue($prefix.strtolower((string) $category), '', $keys);
 
       return array($key => $value);
     }

--- a/lib/controller/sfController.class.php
+++ b/lib/controller/sfController.class.php
@@ -108,8 +108,8 @@ abstract class sfController
       $this->context->getConfigCache()->import('modules/'.$moduleName.'/config/generator.yml', false, true);
 
       // one action per file or one file for all actions
-      $classFile   = strtolower($extension);
-      $classSuffix = ucfirst(strtolower($extension));
+      $classFile   = strtolower((string) $extension);
+      $classSuffix = ucfirst(strtolower((string) $extension));
       $file        = $dir.'/'.$controllerName.$classSuffix.'.class.php';
       if (is_readable($file))
       {
@@ -208,15 +208,15 @@ abstract class sfController
     $this->getActionStack()->addEntry($moduleName, $actionName, $actionInstance);
 
     // include module configuration
-    $viewClass = sfConfig::get('mod_'.strtolower($moduleName).'_view_class', false);
+    $viewClass = sfConfig::get('mod_'.strtolower((string) $moduleName).'_view_class', false);
     require($this->context->getConfigCache()->checkConfig('modules/'.$moduleName.'/config/module.yml'));
     if (false !== $viewClass)
     {
-      sfConfig::set('mod_'.strtolower($moduleName).'_view_class', $viewClass);
+      sfConfig::set('mod_'.strtolower((string) $moduleName).'_view_class', $viewClass);
     }
 
     // module enabled?
-    if (sfConfig::get('mod_'.strtolower($moduleName).'_enabled'))
+    if (sfConfig::get('mod_'.strtolower((string) $moduleName).'_enabled'))
     {
       // check for a module config.php
       $moduleConfig = sfConfig::get('sf_app_module_dir').'/'.$moduleName.'/config/config.php';
@@ -296,7 +296,7 @@ abstract class sfController
    */
   protected function getController($moduleName, $controllerName, $extension)
   {
-    $classSuffix = ucfirst(strtolower($extension));
+    $classSuffix = ucfirst(strtolower((string) $extension));
     if (!isset($this->controllerClasses[$moduleName.'_'.$controllerName.'_'.$classSuffix]))
     {
       if (!$this->controllerExists($moduleName, $controllerName, $extension, true))
@@ -371,7 +371,7 @@ abstract class sfController
     else
     {
       // view class (as configured in module.yml or defined in action)
-      $class = sfConfig::get('mod_'.strtolower($moduleName).'_view_class', 'sfPHP').'View';
+      $class = sfConfig::get('mod_'.strtolower((string) $moduleName).'_view_class', 'sfPHP').'View';
     }
 
     return new $class($this->context, $moduleName, $actionName, $viewName);
@@ -411,8 +411,8 @@ abstract class sfController
     // set viewName if needed
     if ($viewName)
     {
-      $currentViewName = sfConfig::get('mod_'.strtolower($module).'_view_class');
-      sfConfig::set('mod_'.strtolower($module).'_view_class', $viewName);
+      $currentViewName = sfConfig::get('mod_'.strtolower((string) $module).'_view_class');
+      sfConfig::set('mod_'.strtolower((string) $module).'_view_class', $viewName);
     }
 
     try
@@ -428,7 +428,7 @@ abstract class sfController
       // remove viewName
       if ($viewName)
       {
-        sfConfig::set('mod_'.strtolower($module).'_view_class', $currentViewName);
+        sfConfig::set('mod_'.strtolower((string) $module).'_view_class', $currentViewName);
       }
 
       throw $e;
@@ -462,7 +462,7 @@ abstract class sfController
     // remove viewName
     if ($viewName)
     {
-      sfConfig::set('mod_'.strtolower($module).'_view_class', $currentViewName);
+      sfConfig::set('mod_'.strtolower((string) $module).'_view_class', $currentViewName);
     }
 
     return $presentation;

--- a/lib/debug/sfWebDebugPanelConfig.class.php
+++ b/lib/debug/sfWebDebugPanelConfig.class.php
@@ -71,7 +71,7 @@ class sfWebDebugPanelConfig extends sfWebDebugPanel
    */
   protected function formatArrayAsHtml($id, $values)
   {
-    $id = ucfirst(strtolower($id));
+    $id = ucfirst(strtolower((string) $id));
 
     return '
     <h2>'.$id.' '.$this->getToggler('sfWebDebug'.$id).'</h2>

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1035,7 +1035,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   public function renderFormTag($url, array $attributes = array())
   {
     $attributes['action'] = $url;
-    $attributes['method'] = isset($attributes['method']) ? strtolower($attributes['method']) : 'post';
+    $attributes['method'] = isset($attributes['method']) ? strtolower((string) $attributes['method']) : 'post';
     if ($this->isMultipart())
     {
       $attributes['enctype'] = 'multipart/form-data';

--- a/lib/helper/PartialHelper.php
+++ b/lib/helper/PartialHelper.php
@@ -84,7 +84,7 @@ function has_component_slot($name)
   {
     return false;
   }
-  
+
   // check to see if component slot is empty (null)
   if ($viewInstance->getComponentSlot($name))
   {
@@ -138,7 +138,7 @@ function get_component($moduleName, $componentName, $vars = array())
 
   require($context->getConfigCache()->checkConfig('modules/'.$moduleName.'/config/module.yml'));
 
-  $class = sfConfig::get('mod_'.strtolower($moduleName).'_partial_view_class', 'sf').'PartialView';
+  $class = sfConfig::get('mod_'.strtolower((string) $moduleName).'_partial_view_class', 'sf').'PartialView';
   $view = new $class($context, $moduleName, $actionName, '');
   $view->setPartialVars(true === sfConfig::get('sf_escaping_strategy') ? sfOutputEscaper::unescape($vars) : $vars);
 
@@ -213,7 +213,7 @@ function get_partial($templateName, $vars = array())
   }
   $actionName = '_'.$templateName;
 
-  $class = sfConfig::get('mod_'.strtolower($moduleName).'_partial_view_class', 'sf').'PartialView';
+  $class = sfConfig::get('mod_'.strtolower((string) $moduleName).'_partial_view_class', 'sf').'PartialView';
   $view = new $class($context, $moduleName, $actionName, '');
   $view->setPartialVars(true === sfConfig::get('sf_escaping_strategy') ? sfOutputEscaper::unescape($vars) : $vars);
 

--- a/lib/helper/TextHelper.php
+++ b/lib/helper/TextHelper.php
@@ -155,7 +155,7 @@ function excerpt_text($text, $phrase, $radius = 100, $excerpt_string = '...', $e
   $strtolower = ($mbstring) ? 'mb_strtolower' : 'strtolower';
   $substr = ($mbstring) ? 'mb_substr' : 'substr';
 
-  $found_pos = $strpos($strtolower($text), $strtolower($phrase));
+  $found_pos = $strpos($strtolower((string) $text), $strtolower((string) $phrase));
   $return_string = '';
   if ($found_pos !== false)
   {

--- a/lib/helper/UrlHelper.php
+++ b/lib/helper/UrlHelper.php
@@ -438,7 +438,7 @@ function form_tag($url_for_options = '', $options = array())
 
   $html_options = $options;
 
-  $html_options['method'] = isset($html_options['method']) ? strtolower($html_options['method']) : 'post';
+  $html_options['method'] = isset($html_options['method']) ? strtolower((string) $html_options['method']) : 'post';
 
   if (_get_option($html_options, 'multipart'))
   {
@@ -496,7 +496,7 @@ function mail_to($email, $name = '', $options = array(), $default_value = array(
   $default = array();
   foreach ($default_tmp as $key => $value)
   {
-    $default[] = urlencode($key).'='.urlencode($value);
+    $default[] = urlencode((string) $key).'='.urlencode((string) $value);
   }
   $options = count($default) ? '?'.implode('&', $default) : '';
 
@@ -605,10 +605,10 @@ function _method_javascript_function($method)
 {
   $function = "var f = document.createElement('form'); f.style.display = 'none'; this.parentNode.appendChild(f); f.method = 'post'; f.action = this.href;";
 
-  if ('post' != strtolower($method))
+  if ('post' != strtolower((string) $method))
   {
     $function .= "var m = document.createElement('input'); m.setAttribute('type', 'hidden'); ";
-    $function .= sprintf("m.setAttribute('name', 'sf_method'); m.setAttribute('value', '%s'); f.appendChild(m);", strtolower($method));
+    $function .= sprintf("m.setAttribute('name', 'sf_method'); m.setAttribute('value', '%s'); f.appendChild(m);", strtolower((string) $method));
   }
 
   // CSRF protection

--- a/lib/i18n/sfNumberFormat.class.php
+++ b/lib/i18n/sfNumberFormat.class.php
@@ -116,7 +116,7 @@ class sfNumberFormat
   {
     $this->setPattern($pattern);
 
-    if (strtolower($pattern) == 'p')
+    if (strtolower((string) $pattern) == 'p')
     {
       $number *= 100;
     }

--- a/lib/mailer/sfMailer.class.php
+++ b/lib/mailer/sfMailer.class.php
@@ -94,7 +94,7 @@ class sfMailer extends Swift_Mailer
         {
           foreach ($transport->getExtensionHandlers() as $handler)
           {
-            if (in_array(strtolower($method), array_map('strtolower', (array) $handler->exposeMixinMethods())))
+            if (in_array(strtolower((string) $method), array_map('strtolower', (array) $handler->exposeMixinMethods())))
             {
               $transport->$method($value);
             }

--- a/lib/plugin/sfPearRestPlugin.class.php
+++ b/lib/plugin/sfPearRestPlugin.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -86,7 +86,7 @@ class sfPearRestPlugin extends sfPearRest11
 
     if (PEAR::isError($info))
     {
-      throw new sfPluginRestException(sprintf('Unable to get plugin licence information for plugin "%s": %s', $plugin, $info->getMessage())); 
+      throw new sfPluginRestException(sprintf('Unable to get plugin licence information for plugin "%s": %s', $plugin, $info->getMessage()));
     }
 
     if (null === $info)
@@ -113,7 +113,7 @@ class sfPearRestPlugin extends sfPearRest11
    */
   public function getPluginVersions($plugin, $stability = null)
   {
-    $allreleases = $this->_rest->retrieveData($this->restBase.'r/'.strtolower($plugin).'/allreleases.xml');
+    $allreleases = $this->_rest->retrieveData($this->restBase.'r/'.strtolower((string) $plugin).'/allreleases.xml');
     if (PEAR::isError($allreleases))
     {
       throw new sfPluginRestException(sprintf('Unable to get information for plugin "%s": %s', $plugin, $allreleases->getMessage()));
@@ -159,7 +159,7 @@ class sfPearRestPlugin extends sfPearRest11
    */
   public function getPluginDependencies($plugin, $version)
   {
-    $dependencies = $this->_rest->retrieveData($this->restBase.'r/'.strtolower($plugin).'/deps.'.$version.'.txt');
+    $dependencies = $this->_rest->retrieveData($this->restBase.'r/'.strtolower((string) $plugin).'/deps.'.$version.'.txt');
     if (PEAR::isError($dependencies))
     {
       throw new sfPluginRestException(sprintf('Unable to get dependencies information for plugin "%s": %s', $plugin, $dependencies->getMessage()));

--- a/lib/plugins/sfDoctrinePlugin/data/generator/sfDoctrineModule/admin/parts/sortingAction.php
+++ b/lib/plugins/sfDoctrinePlugin/data/generator/sfDoctrineModule/admin/parts/sortingAction.php
@@ -5,7 +5,7 @@
       return;
     }
 
-    if (!in_array(strtolower($sort[1]), array('asc', 'desc')))
+    if (!in_array(strtolower((string) $sort[1]), array('asc', 'desc')))
     {
       $sort[1] = 'asc';
     }

--- a/lib/plugins/sfDoctrinePlugin/data/generator/sfDoctrineModule/admin/template/templates/_filters.php
+++ b/lib/plugins/sfDoctrinePlugin/data/generator/sfDoctrineModule/admin/template/templates/_filters.php
@@ -27,7 +27,7 @@
             'help'       => $field->getConfig('help'),
             'form'       => $form,
             'field'      => $field,
-            'class'      => 'sf_admin_form_row sf_admin_'.strtolower($field->getType()).' sf_admin_filter_field_'.$name,
+            'class'      => 'sf_admin_form_row sf_admin_'.strtolower((string) $field->getType()).' sf_admin_filter_field_'.$name,
           )) ?]
         [?php endforeach; ?]
       </tbody>

--- a/lib/plugins/sfDoctrinePlugin/data/generator/sfDoctrineModule/admin/template/templates/_form_fieldset.php
+++ b/lib/plugins/sfDoctrinePlugin/data/generator/sfDoctrineModule/admin/template/templates/_form_fieldset.php
@@ -1,4 +1,4 @@
-<fieldset id="sf_fieldset_[?php echo preg_replace('/[^a-z0-9_]/', '_', strtolower($fieldset)) ?]">
+<fieldset id="sf_fieldset_[?php echo preg_replace('/[^a-z0-9_]/', '_', strtolower((string) $fieldset)) ?]">
   [?php if ('NONE' != $fieldset): ?]
     <h2>[?php echo __($fieldset, array(), '<?php echo $this->getI18nCatalogue() ?>') ?]</h2>
   [?php endif; ?]
@@ -12,7 +12,7 @@
       'help'       => $field->getConfig('help'),
       'form'       => $form,
       'field'      => $field,
-      'class'      => 'sf_admin_form_row sf_admin_'.strtolower($field->getType()).' sf_admin_form_field_'.$name,
+      'class'      => 'sf_admin_form_row sf_admin_'.strtolower((string) $field->getType()).' sf_admin_form_field_'.$name,
     )) ?]
   [?php endforeach; ?]
 </fieldset>

--- a/lib/plugins/sfDoctrinePlugin/data/generator/sfDoctrineModule/admin/template/templates/_list_td_tabular.php
+++ b/lib/plugins/sfDoctrinePlugin/data/generator/sfDoctrineModule/admin/template/templates/_list_td_tabular.php
@@ -5,5 +5,5 @@
 </td>
 
 EOF
-, strtolower($field->getType()), $name, $this->renderField($field)), $field->getConfig()) ?>
+, strtolower((string) $field->getType()), $name, $this->renderField($field)), $field->getConfig()) ?>
 <?php endforeach; ?>

--- a/lib/plugins/sfDoctrinePlugin/data/generator/sfDoctrineModule/admin/template/templates/_list_th_tabular.php
+++ b/lib/plugins/sfDoctrinePlugin/data/generator/sfDoctrineModule/admin/template/templates/_list_th_tabular.php
@@ -1,6 +1,6 @@
 <?php foreach ($this->configuration->getValue('list.display') as $name => $field): ?>
 [?php slot('sf_admin.current_header') ?]
-<th class="sf_admin_<?php echo strtolower($field->getType()) ?> sf_admin_list_th_<?php echo $name ?>">
+<th class="sf_admin_<?php echo strtolower((string) $field->getType()) ?> sf_admin_list_th_<?php echo $name ?>">
 <?php if ($field->isReal()): ?>
   [?php if ('<?php echo $name ?>' == $sort[0]): ?]
     [?php echo link_to(__('<?php echo $field->getConfig('label', '', true) ?>', array(), '<?php echo $this->getI18nCatalogue() ?>'), '@<?php echo $this->getUrlForAction('list') ?>', array('query_string' => 'sort=<?php echo $name ?>&sort_type='.($sort[1] == 'asc' ? 'desc' : 'asc'))) ?]

--- a/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineColumn.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineColumn.class.php
@@ -203,7 +203,7 @@ class sfDoctrineColumn implements ArrayAccess
     {
       $local = (array) $relation['local'];
       $local = array_map('strtolower', $local);
-      if (in_array(strtolower($this->name), $local))
+      if (in_array(strtolower((string) $this->name), $local))
       {
         return $relation[$key];
       }
@@ -268,7 +268,7 @@ class sfDoctrineColumn implements ArrayAccess
     {
       $local = (array) $relation['local'];
       $local = array_map('strtolower', $local);
-      if (in_array(strtolower($this->name), $local))
+      if (in_array(strtolower((string) $this->name), $local))
       {
         $this->foreignClassName = $relation['class'];
         if ($relation->getType() === Doctrine_Relation::ONE)

--- a/lib/plugins/sfDoctrinePlugin/lib/record/sfDoctrineRecord.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/record/sfDoctrineRecord.class.php
@@ -152,7 +152,7 @@ abstract class sfDoctrineRecord extends Doctrine_Record
         }
         else if ($table->hasField($fieldName = $table->getFieldName($name)))
         {
-          $entityNameLower = strtolower($fieldName);
+          $entityNameLower = strtolower((string) $fieldName);
           if ($table->hasField($entityNameLower))
           {
             $entityName = $entityNameLower;
@@ -166,11 +166,11 @@ abstract class sfDoctrineRecord extends Doctrine_Record
           if ($table->hasField($underScored) || $table->hasRelation($underScored))
           {
             $entityName = $underScored;
-          } else if ($table->hasField(strtolower($name)) || $table->hasRelation(strtolower($name))) {
-            $entityName = strtolower($name);
+          } else if ($table->hasField(strtolower((string) $name)) || $table->hasRelation(strtolower((string) $name))) {
+            $entityName = strtolower((string) $name);
           } else {
             $camelCase = $table->getFieldName(sfInflector::camelize($name));
-            $camelCase = strtolower($camelCase[0]).substr($camelCase, 1, strlen($camelCase));
+            $camelCase = strtolower((string) $camelCase[0]).substr($camelCase, 1, strlen($camelCase));
             if ($table->hasField($camelCase) || $table->hasRelation($camelCase))
             {
               $entityName = $camelCase;

--- a/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineCompileTask.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineCompileTask.class.php
@@ -66,7 +66,7 @@ EOF;
     $drivers = array();
     foreach ($databaseManager->getNames() as $name)
     {
-      $drivers[] = strtolower($databaseManager->getDatabase($name)->getDoctrineConnection()->getDriverName());
+      $drivers[] = strtolower((string) $databaseManager->getDatabase($name)->getDoctrineConnection()->getDriverName());
     }
     $drivers = array_unique($drivers);
 

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -507,7 +507,7 @@ class sfWebRequest extends sfRequest
           {
             if ($i == 0)
             {
-              $lang = strtolower($codes[0]);
+              $lang = strtolower((string) $codes[0]);
             }
             else
             {
@@ -638,9 +638,9 @@ class sfWebRequest extends sfRequest
     $pathArray = $this->getPathInfoArray();
 
     return
-      (isset($pathArray['HTTPS']) && (('on' == strtolower($pathArray['HTTPS']) || 1 == $pathArray['HTTPS'])))
+      (isset($pathArray['HTTPS']) && (('on' == strtolower((string) $pathArray['HTTPS']) || 1 == $pathArray['HTTPS'])))
       ||
-      ($this->getOption('trust_proxy') && isset($pathArray['HTTP_SSL_HTTPS']) && (('on' == strtolower($pathArray['HTTP_SSL_HTTPS']) || 1 == $pathArray['HTTP_SSL_HTTPS'])))
+      ($this->getOption('trust_proxy') && isset($pathArray['HTTP_SSL_HTTPS']) && (('on' == strtolower((string) $pathArray['HTTP_SSL_HTTPS']) || 1 == $pathArray['HTTP_SSL_HTTPS'])))
       ||
       ($this->getOption('trust_proxy') && $this->isForwardedSecure())
     ;
@@ -655,7 +655,7 @@ class sfWebRequest extends sfRequest
   {
     $pathArray = $this->getPathInfoArray();
 
-    return isset($pathArray['HTTP_X_FORWARDED_PROTO']) && 'https' == strtolower($pathArray['HTTP_X_FORWARDED_PROTO']);
+    return isset($pathArray['HTTP_X_FORWARDED_PROTO']) && 'https' == strtolower((string) $pathArray['HTTP_X_FORWARDED_PROTO']);
   }
 
   /**

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -413,7 +413,7 @@ class sfWebResponse extends sfResponse
    */
   protected function normalizeHeaderName($name)
   {
-    return strtr(ucwords(strtr(strtolower($name), array('_' => ' ', '-' => ' '))), array(' ' => '-'));
+    return strtr(ucwords(strtr(strtolower((string) $name), array('_' => ' ', '-' => ' '))), array(' ' => '-'));
   }
 
   /**
@@ -426,7 +426,7 @@ class sfWebResponse extends sfResponse
    */
   static public function getDate($timestamp, $type = 'rfc1123')
   {
-    $type = strtolower($type);
+    $type = strtolower((string) $type);
 
     if ($type == 'rfc1123')
     {
@@ -486,7 +486,7 @@ class sfWebResponse extends sfResponse
         $currentHeaders[$tmp[0]] = isset($tmp[1]) ? $tmp[1] : null;
       }
     }
-    $currentHeaders[str_replace('_', '-', strtolower($name))] = $value;
+    $currentHeaders[str_replace('_', '-', strtolower((string) $name))] = $value;
 
     $headers = array();
     foreach ($currentHeaders as $key => $value)
@@ -561,7 +561,7 @@ class sfWebResponse extends sfResponse
    */
   public function addMeta($key, $value, $replace = true, $escape = true)
   {
-    $key = strtolower($key);
+    $key = strtolower((string) $key);
 
     if (null === $value)
     {

--- a/lib/routing/sfRequestRoute.class.php
+++ b/lib/routing/sfRequestRoute.class.php
@@ -57,7 +57,7 @@ class sfRequestRoute extends sfRoute
     }
 
     // enforce the sf_method requirement
-    if (in_array(strtolower($context['method']), $this->requirements['sf_method']))
+    if (in_array(strtolower((string) $context['method']), $this->requirements['sf_method']))
     {
       return $parameters;
     }
@@ -78,7 +78,7 @@ class sfRequestRoute extends sfRoute
     if (isset($params['sf_method']))
     {
       // enforce the sf_method requirement
-      if (!in_array(strtolower($params['sf_method']), $this->requirements['sf_method']))
+      if (!in_array(strtolower((string) $params['sf_method']), $this->requirements['sf_method']))
       {
         return false;
       }

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -237,7 +237,7 @@ class sfRoute implements Serializable
       uasort($variables, array('sfRoute', 'generateCompareVarsByStrlen'));
       foreach ($variables as $variable => $value)
       {
-        $url = str_replace($value, urlencode($tparams[$variable]), $url);
+        $url = str_replace($value, urlencode((string) $tparams[$variable]), $url);
       }
 
       if(!in_array($this->suffix, $this->options['segment_separators']))
@@ -286,7 +286,7 @@ class sfRoute implements Serializable
         case 'variable':
           if (!$optional || !isset($this->defaults[$token[3]]) || (isset($parameters[$token[3]]) && $parameters[$token[3]] != $this->defaults[$token[3]]))
           {
-            $url[] = urlencode($parameters[$token[3]]);
+            $url[] = urlencode((string) $parameters[$token[3]]);
             $optional = false;
           }
           break;
@@ -753,12 +753,12 @@ class sfRoute implements Serializable
       {
         foreach ($value as $v)
         {
-          $tmp[] = $key.'='.urlencode($v);
+          $tmp[] = $key.'='.urlencode((string) $v);
         }
       }
       else
       {
-        $tmp[] = urlencode($key).'/'.urlencode($value);
+        $tmp[] = urlencode((string) $key).'/'.urlencode((string) $value);
       }
     }
     $tmp = implode('/', $tmp);

--- a/lib/service/sfServiceContainer.class.php
+++ b/lib/service/sfServiceContainer.class.php
@@ -70,7 +70,7 @@ class sfServiceContainer implements sfServiceContainerInterface
     $this->parameters = array();
     foreach ($parameters as $key => $value)
     {
-      $this->parameters[strtolower($key)] = $value;
+      $this->parameters[strtolower((string) $key)] = $value;
     }
   }
 
@@ -107,7 +107,7 @@ class sfServiceContainer implements sfServiceContainerInterface
   {
     if ($this->hasParameter($name))
     {
-      return $this->parameters[strtolower($name)];
+      return $this->parameters[strtolower((string) $name)];
     }
 
     if (sfConfig::has($name))
@@ -126,7 +126,7 @@ class sfServiceContainer implements sfServiceContainerInterface
    */
   public function setParameter($name, $value)
   {
-    $this->parameters[strtolower($name)] = $value;
+    $this->parameters[strtolower((string) $name)] = $value;
   }
 
   /**
@@ -138,7 +138,7 @@ class sfServiceContainer implements sfServiceContainerInterface
    */
   public function hasParameter($name)
   {
-    return array_key_exists(strtolower($name), $this->parameters);
+    return array_key_exists(strtolower((string) $name), $this->parameters);
   }
 
   /**

--- a/lib/service/sfServiceContainerDumperPhp.class.php
+++ b/lib/service/sfServiceContainerDumperPhp.class.php
@@ -339,7 +339,7 @@ EOF;
     }
     elseif (is_object($value) && $value instanceof sfServiceParameter)
     {
-      return sprintf("\$this->getParameter('%s')", strtolower($value));
+      return sprintf("\$this->getParameter('%s')", strtolower((string) $value));
     }
     elseif (is_string($value))
     {
@@ -347,7 +347,7 @@ EOF;
       {
         // we do this to deal with non string values (boolean, integer, ...)
         // the preg_replace_callback converts them to strings
-        return sprintf("\$this->getParameter('%s')", strtolower($match[1]));
+        return sprintf("\$this->getParameter('%s')", strtolower((string) $match[1]));
       }
       else
       {
@@ -371,7 +371,7 @@ EOF;
 
   public function replaceParameter($match)
   {
-    return sprintf("'.\$this->getParameter('%s').'", strtolower($match[2]));
+    return sprintf("'.\$this->getParameter('%s').'", strtolower((string) $match[2]));
   }
 
   protected function getServiceCall($id)

--- a/lib/service/sfServiceContainerLoaderArray.class.php
+++ b/lib/service/sfServiceContainerLoaderArray.class.php
@@ -31,7 +31,7 @@ class sfServiceContainerLoaderArray extends sfServiceContainerLoader
     {
       foreach ($content['parameters'] as $key => $value)
       {
-        $parameters[strtolower($key)] = $this->resolveServices($value);
+        $parameters[strtolower((string) $key)] = $this->resolveServices($value);
       }
     }
 

--- a/lib/task/generator/sfGenerateProjectTask.class.php
+++ b/lib/task/generator/sfGenerateProjectTask.class.php
@@ -87,7 +87,7 @@ EOF;
       throw new sfCommandException(sprintf('A symfony project already exists in this directory (%s).', getcwd()));
     }
 
-    if (!in_array(strtolower($options['orm']), array('doctrine', 'none')))
+    if (!in_array(strtolower((string) $options['orm']), array('doctrine', 'none')))
     {
       throw new InvalidArgumentException(sprintf('Invalid ORM name "%s".', $options['orm']));
     }
@@ -98,7 +98,7 @@ EOF;
     }
 
     // clean orm option
-    $options['orm'] = ucfirst(strtolower($options['orm']));
+    $options['orm'] = ucfirst(strtolower((string) $options['orm']));
 
     $this->arguments = $arguments;
     $this->options = $options;

--- a/lib/task/plugin/sfPluginInstallTask.class.php
+++ b/lib/task/plugin/sfPluginInstallTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -111,7 +111,7 @@ EOF;
 
       if (false !== $license)
       {
-        $temp = trim(str_replace('license', '', strtolower($license)));
+        $temp = trim(str_replace('license', '', strtolower((string) $license)));
         if (null !== $license && !in_array($temp, array('mit', 'bsd', 'lgpl', 'php', 'apache')))
         {
           throw new sfCommandException(sprintf('The license of this plugin "%s" is not MIT like (use --force-license to force installation).', $license));

--- a/lib/task/sfTask.class.php
+++ b/lib/task/sfTask.class.php
@@ -496,18 +496,18 @@ abstract class sfTask
   public function askConfirmation($question, $style = 'QUESTION', $default = true)
   {
     $answer = 'z';
-    while ($answer && !in_array(strtolower($answer[0]), array('y', 'n')))
+    while ($answer && !in_array(strtolower((string) $answer[0]), array('y', 'n')))
     {
       $answer = $this->ask($question, $style);
     }
 
     if (false === $default)
     {
-      return $answer && 'y' == strtolower($answer[0]);
+      return $answer && 'y' == strtolower((string) $answer[0]);
     }
     else
     {
-      return !$answer || 'y' == strtolower($answer[0]);
+      return !$answer || 'y' == strtolower((string) $answer[0]);
     }
   }
 

--- a/lib/test/sfTestFunctionalBase.class.php
+++ b/lib/test/sfTestFunctionalBase.class.php
@@ -236,7 +236,7 @@ abstract class sfTestFunctionalBase
 
     $uri = $this->browser->fixUri($uri);
 
-    $this->test()->comment(sprintf('%s %s', strtolower($method), $uri));
+    $this->test()->comment(sprintf('%s %s', strtolower((string) $method), $uri));
 
     foreach ($this->testers as $tester)
     {

--- a/lib/util/sfDomCssSelector.class.php
+++ b/lib/util/sfDomCssSelector.class.php
@@ -118,7 +118,7 @@ class sfDomCssSelector implements Countable, Iterator
           $id = substr($token, $pos + 1);
           $xpath = new DomXPath($root_node);
           $element = $xpath->query(sprintf("//*[@id = '%s']", $id))->item(0);
-          if (!$element || ($tagName && strtolower($element->nodeName) != $tagName))
+          if (!$element || ($tagName && strtolower((string) $element->nodeName) != $tagName))
           {
             // tag with that ID not found
             return array();

--- a/lib/util/sfFinder.class.php
+++ b/lib/util/sfFinder.class.php
@@ -97,7 +97,7 @@ class sfFinder
    */
   public function setType($name)
   {
-    $name = strtolower($name);
+    $name = strtolower((string) $name);
 
     if (substr($name, 0, 3) === 'dir')
     {
@@ -759,12 +759,12 @@ class sfNumberCompare
 
     $target = array_key_exists(2, $matches) ? $matches[2] : '';
     $magnitude = array_key_exists(3, $matches) ? $matches[3] : '';
-    if (strtolower($magnitude) === 'k')  $target *=           1000;
-    if (strtolower($magnitude) === 'ki') $target *=           1024;
-    if (strtolower($magnitude) === 'm')  $target *=        1000000;
-    if (strtolower($magnitude) === 'mi') $target *=      1024*1024;
-    if (strtolower($magnitude) === 'g')  $target *=     1000000000;
-    if (strtolower($magnitude) === 'gi') $target *= 1024*1024*1024;
+    if (strtolower((string) $magnitude) === 'k')  $target *=           1000;
+    if (strtolower((string) $magnitude) === 'ki') $target *=           1024;
+    if (strtolower((string) $magnitude) === 'm')  $target *=        1000000;
+    if (strtolower((string) $magnitude) === 'mi') $target *=      1024*1024;
+    if (strtolower((string) $magnitude) === 'g')  $target *=     1000000000;
+    if (strtolower((string) $magnitude) === 'gi') $target *= 1024*1024*1024;
 
     $comparison = array_key_exists(1, $matches) ? $matches[1] : '==';
     if ($comparison === '==' || $comparison == '')

--- a/lib/util/sfInflector.class.php
+++ b/lib/util/sfInflector.class.php
@@ -45,7 +45,7 @@ class sfInflector
     $tmp = sfToolkit::pregtr($tmp, array('/([A-Z]+)([A-Z][a-z])/' => '\\1_\\2',
                                          '/([a-z\d])([A-Z])/'     => '\\1_\\2'));
 
-    return strtolower($tmp);
+    return strtolower((string) $tmp);
   }
 
   /**

--- a/lib/util/sfToolkit.class.php
+++ b/lib/util/sfToolkit.class.php
@@ -305,7 +305,7 @@ class sfToolkit
   {
     // lowercase our value for comparison
     $value  = trim($value);
-    $lvalue = strtolower($value);
+    $lvalue = strtolower((string) $value);
 
     if (in_array($lvalue, array('null', '~', '')))
     {
@@ -354,7 +354,7 @@ class sfToolkit
     }
 
     return preg_replace_callback('/%(.+?)%/', function ($v) {
-      return sfConfig::has(strtolower($v[1])) ? sfConfig::get(strtolower($v[1])) : '%'.$v[1].'%';
+      return sfConfig::has(strtolower((string) $v[1])) ? sfConfig::get(strtolower((string) $v[1])) : '%'.$v[1].'%';
     }, $value);
   }
 

--- a/lib/validator/sfValidatorFile.class.php
+++ b/lib/validator/sfValidatorFile.class.php
@@ -132,7 +132,7 @@ class sfValidatorFile extends sfValidatorBase
           $max = min($max, $this->getOption('max_size'));
         }
         throw new sfValidatorError($this, 'max_size', array(
-          'max_size' => round($max / 1024, 0), 
+          'max_size' => round($max / 1024, 0),
           'size' => (int) $value['size']
         ));
       case UPLOAD_ERR_FORM_SIZE:
@@ -154,7 +154,7 @@ class sfValidatorFile extends sfValidatorBase
     if ($this->hasOption('max_size') && $this->getOption('max_size') < (int) $value['size'])
     {
       throw new sfValidatorError($this, 'max_size', array(
-        'max_size' => round($this->getOption('max_size') / 1024, 0), 
+        'max_size' => round($this->getOption('max_size') / 1024, 0),
         'size' => (int) $value['size']
       ));
     }
@@ -198,11 +198,11 @@ class sfValidatorFile extends sfValidatorBase
 
       if (null !== $type && $type !== false)
       {
-        return strtolower($type);
+        return strtolower((string) $type);
       }
     }
 
-    return strtolower($fallback);
+    return strtolower((string) $fallback);
   }
 
   /**

--- a/lib/validator/sfValidatorFromDescription.class.php
+++ b/lib/validator/sfValidatorFromDescription.class.php
@@ -104,7 +104,7 @@ class sfValidatorFromDescription extends sfValidatorDecorator
         // arguments (optional)
         $arguments = $this->parseArguments($string, $i);
 
-        $tokens[] = new sfValidatorFDTokenOperator(strtolower($match[1]), $arguments);
+        $tokens[] = new sfValidatorFDTokenOperator(strtolower((string) $match[1]), $arguments);
       }
       else if (preg_match('/^(?:([a-z0-9_\-]+)\:)?([a-z0-9_\-]+)/i', substr($string, $i), $match))
       {

--- a/lib/validator/sfValidatorSchema.class.php
+++ b/lib/validator/sfValidatorSchema.class.php
@@ -396,7 +396,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
   {
     $value    = trim($value);
     $number   = (float) $value;
-    $modifier = strtolower($value[strlen($value) - 1]);
+    $modifier = strtolower((string) $value[strlen($value) - 1]);
 
     $exp_by_modifier = array(
       'k' => 1,

--- a/lib/view/sfView.class.php
+++ b/lib/view/sfView.class.php
@@ -117,7 +117,7 @@ abstract class sfView
     $this->attributeHolder = $this->initializeAttributeHolder();
 
     $this->parameterHolder = new sfParameterHolder();
-    $this->parameterHolder->add(sfConfig::get('mod_'.strtolower($moduleName).'_view_param', array()));
+    $this->parameterHolder->add(sfConfig::get('mod_'.strtolower((string) $moduleName).'_view_param', array()));
 
     $request = $context->getRequest();
 

--- a/lib/view/sfViewCacheManager.class.php
+++ b/lib/view/sfViewCacheManager.class.php
@@ -263,7 +263,7 @@ class sfViewCacheManager
     $hostName = preg_replace('/[^a-z0-9\*]/i', '_', $hostName);
     $hostName = preg_replace('/_+/', '_', $hostName);
 
-    return strtolower($hostName);
+    return strtolower((string) $hostName);
   }
 
   /**
@@ -307,7 +307,7 @@ class sfViewCacheManager
     {
       foreach ($options['vary'] as $key => $name)
       {
-        $options['vary'][$key] = str_replace('_', '-', strtolower($name));
+        $options['vary'][$key] = str_replace('_', '-', strtolower((string) $name));
       }
     }
 

--- a/lib/widget/sfWidget.class.php
+++ b/lib/widget/sfWidget.class.php
@@ -332,7 +332,7 @@ abstract class sfWidget
       return '';
     }
 
-    return sprintf('<%s%s%s', $tag, $this->attributesToHtml($attributes), self::$xhtml ? ' />' : (strtolower($tag) == 'input' ? '>' : sprintf('></%s>', $tag)));
+    return sprintf('<%s%s%s', $tag, $this->attributesToHtml($attributes), self::$xhtml ? ' />' : (strtolower((string) $tag) == 'input' ? '>' : sprintf('></%s>', $tag)));
   }
 
   /**

--- a/lib/yaml/sfYamlInline.class.php
+++ b/lib/yaml/sfYamlInline.class.php
@@ -109,11 +109,11 @@ class sfYamlInline
         return "''";
       case preg_match(self::getTimestampRegex(), $value):
         return "'$value'";
-      case in_array(strtolower($value), $trueValues):
+      case in_array(strtolower((string) $value), $trueValues):
         return "'$value'";
-      case in_array(strtolower($value), $falseValues):
+      case in_array(strtolower((string) $value), $falseValues):
         return "'$value'";
-      case in_array(strtolower($value), array('null', '~')):
+      case in_array(strtolower((string) $value), array('null', '~')):
         return "'$value'";
       default:
         return $value;
@@ -387,7 +387,7 @@ class sfYamlInline
 
     switch (true)
     {
-      case 'null' == strtolower($scalar):
+      case 'null' == strtolower((string) $scalar):
       case '' == $scalar:
       case '~' == $scalar:
         return null;
@@ -401,9 +401,9 @@ class sfYamlInline
         $raw = $scalar;
         $cast = (int) $scalar;
         return '0' == $scalar[0] ? octdec($scalar) : (((string) $raw == (string) $cast) ? $cast : $raw);
-      case in_array(strtolower($scalar), $trueValues):
+      case in_array(strtolower((string) $scalar), $trueValues):
         return true;
-      case in_array(strtolower($scalar), $falseValues):
+      case in_array(strtolower((string) $scalar), $falseValues):
         return false;
       case 0 === strpos($scalar, '0x'):
         return hexdec($scalar);

--- a/test/unit/routing/sfRouteTest.php
+++ b/test/unit/routing/sfRouteTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -227,7 +227,7 @@ class MyRoute extends sfRoute
   {
     if (!empty($tparams[$variable]) && (!$optional || !isset($this->defaults[$variable]) || $tparams[$variable] != $this->defaults[$variable]))
     {
-      return $variable . '/' . urlencode($tparams[$variable]);
+      return $variable . '/' . urlencode((string) $tparams[$variable]);
     }
   }
 }


### PR DESCRIPTION
(cherry picked from commit ebb7c6c3f780feb9c3e69caf3dbafcc4cea75f4d)

While we were migrating our application to PHP 8.1, some of our phpunit tests failed, as they somehow managed to get "null" inside symfony internals, where now strings are the only allowed argument types (resulting in deprecation warnings for now, but we configured our test suites to fail on those as well). 

This happend for cases of strtolower() and urlencode() functions. Thus, we simply got our application (test suites) working again by applying explicit string casts to those function calls via simple search-and-replace statements throught all source files. I am aware that this results in possibly many non-required casts, but we wanted to be sure and thus applied the patch to all uses of these functions.

Thought this might be useful for you as well, thus I made this pull request.