### PR TITLE
fix: avoid creating dynamic property $options

### DIFF
--- a/lib/view/sfViewCacheManager.class.php
+++ b/lib/view/sfViewCacheManager.class.php
@@ -21,6 +21,8 @@
  */
 class sfViewCacheManager
 {
+    public $options = array();
+
     protected $cache;
     protected $cacheConfig = array();
     protected $context;


### PR DESCRIPTION
 Dynamic properties are deprecated since PHP8.2