### PR TITLE
8.3 compat/string to array

### DIFF
--- a/lib/util/sfToolkit.class.php
+++ b/lib/util/sfToolkit.class.php
@@ -254,7 +254,7 @@ class sfToolkit
       \s*(?:
         (?=\w+\s*=) | \s*$  # followed by another key= or the end of the string
       )
-    /x', $string, $matches, PREG_SET_ORDER);
+    /x', (string) $string, $matches, PREG_SET_ORDER);
 
         $attributes = array();
         foreach ($matches as $val) {

--- a/test/unit/util/sfToolkitTest.php
+++ b/test/unit/util/sfToolkitTest.php
@@ -15,7 +15,6 @@ $t = new lime_test(96);
 // ::stringToArray()
 $t->diag('::stringToArray()');
 $tests = array(
-    null => array(),
     'foo=bar' => array('foo' => 'bar'),
     'foo1=bar1 foo=bar   ' => array('foo1' => 'bar1', 'foo' => 'bar'),
     'foo1="bar1 foo1"' => array('foo1' => 'bar1 foo1'),
@@ -34,6 +33,8 @@ $tests = array(
 foreach ($tests as $string => $attributes) {
     $t->is(sfToolkit::stringToArray($string), $attributes, '->stringToArray()');
 }
+
+$t->is(sfToolkit::stringToArray(null), array(), '->stringToArray() can accept a null value');
 
 // ::isUTF8()
 $t->diag('::isUTF8()');

--- a/test/unit/util/sfToolkitTest.php
+++ b/test/unit/util/sfToolkitTest.php
@@ -10,11 +10,12 @@
 
 require_once __DIR__.'/../../bootstrap/unit.php';
 
-$t = new lime_test(95);
+$t = new lime_test(96);
 
 // ::stringToArray()
 $t->diag('::stringToArray()');
 $tests = array(
+    null => array(),
     'foo=bar' => array('foo' => 'bar'),
     'foo1=bar1 foo=bar   ' => array('foo1' => 'bar1', 'foo' => 'bar'),
     'foo1="bar1 foo1"' => array('foo1' => 'bar1 foo1'),


### PR DESCRIPTION
Symfony helpers such as `link_to_if`, [set missing variables to `null`](https://github.com/FriendsOfSymfony1/symfony1/blob/2a6803324c48c9edc1a9f19f563e5235dc39f44b/lib/helper/UrlHelper.php#L221), and then [send those null values to `_parse_attributes`](https://github.com/FriendsOfSymfony1/symfony1/blob/2a6803324c48c9edc1a9f19f563e5235dc39f44b/lib/helper/TagHelper.php#L116), which in turn causes a deprecation notice when [`sfToolkit::stringToArray` calls `preg_match_all`](https://github.com/FriendsOfSymfony1/symfony1/blob/2a6803324c48c9edc1a9f19f563e5235dc39f44b/lib/util/sfToolkit.class.php#L257) and the `$subject` variable is null ([it requires a string](https://www.php.net/preg_match_all)).  

> Deprecated: preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated in /path/to/friendsofsymfony1/symfony1/lib/util/sfToolkit.class.php on line 276


This PR simply ensures that the string variable is actually a string when passed to `preg_match_all`.
