### PR TITLE
[8.x Compatiblity] sfDebug::shortenFilePath

### DIFF
--- a/lib/debug/sfDebug.class.php
+++ b/lib/debug/sfDebug.class.php
@@ -235,6 +235,10 @@ class sfDebug
      */
     public static function shortenFilePath($file)
     {
+        if (!$file) {
+            return $file;
+        }
+
         foreach (array('sf_root_dir', 'sf_symfony_lib_dir') as $key) {
             if (0 === strpos($file, $value = sfConfig::get($key))) {
                 $file = str_replace($value, strtoupper($key), $file);

--- a/test/unit/debug/sfDebugTest.php
+++ b/test/unit/debug/sfDebugTest.php
@@ -10,10 +10,13 @@
 
 require_once __DIR__.'/../../bootstrap/unit.php';
 
-$t = new lime_test(1);
+$t = new lime_test(2);
 
 // ::removeObjects()
 $t->diag('::removeObjects()');
 $objectArray = array('foo', 42, new sfDebug(), array('bar', 23, new lime_test(null)));
 $cleanedArray = array('foo', 42, 'sfDebug Object()', array('bar', 23, 'lime_test Object()'));
 $t->is_deeply(sfDebug::removeObjects($objectArray), $cleanedArray, '::removeObjects() converts objects to String representations using the class name');
+
+$t->diag('::shortenFilePath()');
+$t->is(sfDebug::shortenFilePath(null), null, '->shortenFilePath() handles a null value');


### PR DESCRIPTION
When the sfWebDebugPanel is enabled, it calls [formatFileLink](https://github.com/FriendsOfSymfony1/symfony1/blob/2a6803324c48c9edc1a9f19f563e5235dc39f44b/lib/debug/sfWebDebugPanel.class.php#L148) to to make links clickable in the debug panel, but [a filename doesn't always exist](https://github.com/FriendsOfSymfony1/symfony1/blob/2a6803324c48c9edc1a9f19f563e5235dc39f44b/lib/debug/sfWebDebugPanel.class.php#L151).  Regardless, it then tries to [shorten the filename](https://github.com/FriendsOfSymfony1/symfony1/blob/2a6803324c48c9edc1a9f19f563e5235dc39f44b/lib/debug/sfWebDebugPanel.class.php#L161) which results in a deprecation notice due to the [filename being null when calling strpos](https://github.com/FriendsOfSymfony1/symfony1/blob/2a6803324c48c9edc1a9f19f563e5235dc39f44b/lib/debug/sfDebug.class.php#L239).

> Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /path/to/friendsofsymfony1/symfony1/lib/debug/sfDebug.class.php on line 263

Note: This behavior is only observed when the `sfWebDebugLogger` is enabled along with the `xdebug_logging` option in factories.yml:

```
  logger:
    class: sfAggregateLogger
    param:
      level: debug
      loggers:
        sf_web_debug:
          class: sfWebDebugLogger
          param:
            condition:      %SF_WEB_DEBUG%
            xdebug_logging: true
```

This PR fixes the `sfDebug::shortenFilePath` method so it returns early if the path is empty.  Returning the empty value is what it already is doing.

**Note:** I didn't see any tests for this method, so I just added the one to cover this condition.