### PR TITLE
[PHP8] Declare sfDoctrineFormGenerator $params property

### DIFF
--- a/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineFormGenerator.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineFormGenerator.class.php
@@ -36,6 +36,13 @@ class sfDoctrineFormGenerator extends sfGenerator
     public $pluginModels = array();
 
     /**
+     * Array of all configuration params.
+     *
+     * @var array
+     */
+    public $params = array();
+
+    /**
      * Initializes the current sfGenerator instance.
      *
      * @param sfGeneratorManager A sfGeneratorManager instance


### PR DESCRIPTION
The sfDoctrineFormGenerator class [stores a $params property](https://github.com/FriendsOfSymfony1/symfony1/blob/6edd425ca4a60946ed38f103eb25f5831054d34d/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineFormGenerator.class.php#L60) that is not declared in the class, leading to a deprecation notice:

> PHP Deprecated:  Creation of dynamic property sfDoctrineFormGenerator::$params is deprecated in /path/to/friendsofsymfony1/symfony1/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineFormGenerator.class.php on line 61

This PR simply declares the class property to satisfy the deprecation notice.