### PR TITLE
[PHP] Replace default $flags variable with 0

### DIFF
--- a/lib/validator/sfValidatorIp.class.php
+++ b/lib/validator/sfValidatorIp.class.php
@@ -106,7 +106,7 @@ class sfValidatorIp extends sfValidatorString
                 break;
 
             default:
-                $flag = null;
+                $flag = 0;
 
                 break;
         }


### PR DESCRIPTION
The sfValidatorIp class [sets the $flags variable to null by default](https://github.com/FriendsOfSymfony1/symfony1/blob/6edd425ca4a60946ed38f103eb25f5831054d34d/lib/validator/sfValidatorIp.class.php#L109), which is passed into the `$options` parameter of the [filter_var](https://www.php.net/filter_var) function and triggers a PHP deprecation error:

> Deprecated: filter_var(): Passing null to parameter #3 ($options) of type array|int is deprecated in /path/to/friendsofsymfony1/symfony1/lib/validator/sfValidatorIp.class.php on line 104

This PR simply sets the default value of $flags to 0 (zero), which is the default `filter_var` $options value when not passed.

