### PR TITLE
[task] fix return statement missing stan errors

### DIFF
--- a/lib/task/test/sfTestFunctionalTask.class.php
+++ b/lib/task/test/sfTestFunctionalTask.class.php
@@ -108,5 +108,7 @@ EOF;
 
             return $ret;
         }
+
+        return 0;
     }
 }

--- a/lib/task/test/sfTestPluginTask.class.php
+++ b/lib/task/test/sfTestPluginTask.class.php
@@ -67,6 +67,6 @@ EOF;
         $finder = sfFinder::type('file')->follow_link()->name('*Test.php');
         $h->register($finder->in($h->base_dir));
 
-        return $h->run();
+        return $h->run() ? 0 : 1;
     }
 }

--- a/lib/task/test/sfTestUnitTask.class.php
+++ b/lib/task/test/sfTestUnitTask.class.php
@@ -102,5 +102,7 @@ EOF;
 
             return $ret;
         }
+
+        return 0;
     }
 }


### PR DESCRIPTION
issue #348 

Here I'm not sure whether not to introduce constants like symfony/console does:
https://github.com/symfony/symfony/blob/759b6e1126ed7a6bca6fe8f685bf47254aa82496/src/Symfony/Component/Console/Command/Command.php#L38-L40