### PR TITLE
Fix(deprecation) Optional parameter declared before required parameter is implicitly treated as a required parameter

### DIFF
--- a/lib/form/sfFormField.class.php
+++ b/lib/form/sfFormField.class.php
@@ -35,13 +35,13 @@ class sfFormField
     /**
      * Constructor.
      *
-     * @param sfWidgetForm     $widget A sfWidget instance
-     * @param sfFormField      $parent The sfFormField parent instance (null for the root widget)
-     * @param string           $name   The field name
-     * @param string           $value  The field value
-     * @param sfValidatorError $error  A sfValidatorError instance
+     * @param sfWidgetForm          $widget A sfWidget instance
+     * @param sfFormField|null      $parent The sfFormField parent instance (null for the root widget)
+     * @param string                $name   The field name
+     * @param mixed                 $value  The field value
+     * @param sfValidatorError|null $error  A sfValidatorError instance
      */
-    public function __construct(sfWidgetForm $widget, ?sfFormField $parent = null, $name, $value, ?sfValidatorError $error = null)
+    public function __construct(sfWidgetForm $widget, ?sfFormField $parent = null, $name = '', $value = null, ?sfValidatorError $error = null)
     {
         $this->widget = $widget;
         $this->parent = $parent;

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -22,13 +22,13 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
     /**
      * Constructor.
      *
-     * @param sfWidgetFormSchema $widget A sfWidget instance
-     * @param sfFormField        $parent The sfFormField parent instance (null for the root widget)
-     * @param string             $name   The field name
-     * @param string             $value  The field value
-     * @param sfValidatorError   $error  A sfValidatorError instance
+     * @param sfWidgetFormSchema    $widget A sfWidget instance
+     * @param sfFormField|null      $parent The sfFormField parent instance (null for the root widget)
+     * @param string                $name   The field name
+     * @param mixed                 $value  The field value
+     * @param sfValidatorError|null $error  A sfValidatorError instance
      */
-    public function __construct(sfWidgetFormSchema $widget, ?sfFormField $parent = null, $name, $value, ?sfValidatorError $error = null)
+    public function __construct(sfWidgetFormSchema $widget, ?sfFormField $parent = null, $name = '', $value = null, ?sfValidatorError $error = null)
     {
         parent::__construct($widget, $parent, $name, $value, $error);
 


### PR DESCRIPTION
This pr aims to fix the deprecation warnings raised by having required parameters after optional parameters. The given change would have the least possible impact instead of introducing a BC by changing the signature to e. g. require the parameter $parent or change the order.

wdyt? As named parameters have been introduced in PHP 8.0, there might be no call without the parameter being explicitly set to `null` and we could consider it safe to change the signature to `public function __construct(sfWidgetForm $widget, ?sfFormField $parent, $name, $value, ?sfValidatorError $error = null)`?

I'd prefer the changed signature, as it is much cleaner to not introduce a pseudo-optional name and value argument.