### PR TITLE
[cs] introduce modern string functions

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -29,7 +29,9 @@ $config
         '@PhpCsFixer' => true,
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'modernize_strpos' => true,
     ])
+    ->setRiskyAllowed(true)
     ->setCacheFile('.cache/php-cs-fixer.cache')
     ->setFinder($finder)
 ;

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "require": {
         "php" : "^7.4 || ^8.1",
-        "friendsofsymfony1/swiftmailer": "^5.4.13 || ^6.2.5"
+        "friendsofsymfony1/swiftmailer": "^5.4.13 || ^6.2.5",
+        "symfony/polyfill-php80": "^1.29"
     },
     "require-dev": {
         "psr/log": "*"

--- a/lib/autoload/sfCoreAutoload.class.php
+++ b/lib/autoload/sfCoreAutoload.class.php
@@ -510,7 +510,7 @@ class sfCoreAutoload
         $classes = '';
         foreach ($files as $file) {
             $file = str_replace(DIRECTORY_SEPARATOR, '/', $file);
-            $class = basename($file, false === strpos($file, '.class.php') ? '.php' : '.class.php');
+            $class = basename($file, !str_contains($file, '.class.php') ? '.php' : '.class.php');
 
             $contents = file_get_contents($file);
             if (false !== stripos($contents, 'class '.$class)

--- a/lib/cache/sfFileCache.class.php
+++ b/lib/cache/sfFileCache.class.php
@@ -101,7 +101,7 @@ class sfFileCache extends sfCache
      */
     public function removePattern($pattern)
     {
-        if (false !== strpos($pattern, '**')) {
+        if (str_contains($pattern, '**')) {
             $pattern = str_replace(sfCache::SEPARATOR, DIRECTORY_SEPARATOR, $pattern).self::EXTENSION;
 
             $regexp = self::patternToRegexp($pattern);

--- a/lib/command/sfCommandApplication.class.php
+++ b/lib/command/sfCommandApplication.class.php
@@ -557,7 +557,7 @@ abstract class sfCommandApplication
         ini_set('html_errors', false);
         ini_set('magic_quotes_runtime', false);
 
-        if (false === strpos(PHP_SAPI, 'cgi')) {
+        if (!str_contains(PHP_SAPI, 'cgi')) {
             return;
         }
 

--- a/lib/command/sfCommandManager.class.php
+++ b/lib/command/sfCommandManager.class.php
@@ -132,7 +132,7 @@ class sfCommandManager
                 break;
             }
 
-            if ('--' == substr($argument, 0, 2)) {
+            if (str_starts_with($argument, '--')) {
                 $this->parseLongOption(substr($argument, 2));
             } elseif ('-' == $argument[0]) {
                 $this->parseShortOption(substr($argument, 1));

--- a/lib/command/sfCommandManager.class.php
+++ b/lib/command/sfCommandManager.class.php
@@ -316,7 +316,7 @@ class sfCommandManager
      */
     protected function parseLongOption($argument)
     {
-        if (false !== strpos($argument, '=')) {
+        if (str_contains($argument, '=')) {
             list($name, $value) = explode('=', $argument, 2);
 
             if (!$this->optionSet->hasOption($name)) {

--- a/lib/command/sfCommandOption.class.php
+++ b/lib/command/sfCommandOption.class.php
@@ -40,7 +40,7 @@ class sfCommandOption
      */
     public function __construct($name, $shortcut = null, $mode = null, $help = '', $default = null)
     {
-        if ('--' == substr($name, 0, 2)) {
+        if (str_starts_with($name, '--')) {
             $name = substr($name, 2);
         }
 

--- a/lib/config/sfRoutingConfigHandler.class.php
+++ b/lib/config/sfRoutingConfigHandler.class.php
@@ -89,7 +89,7 @@ class sfRoutingConfigHandler extends sfYamlConfigHandler
         foreach ($config as $name => $params) {
             if (
                 (isset($params['type']) && 'collection' == $params['type'])
-                || (isset($params['class']) && false !== strpos($params['class'], 'Collection'))
+                || (isset($params['class']) && str_contains($params['class'], 'Collection'))
             ) {
                 $options = isset($params['options']) ? $params['options'] : [];
                 $options['name'] = $name;

--- a/lib/controller/sfWebController.class.php
+++ b/lib/controller/sfWebController.class.php
@@ -37,7 +37,7 @@ abstract class sfWebController extends sfController
             }
 
             // relative URL?
-            if (0 === strpos($parameters, '/')) {
+            if (str_starts_with($parameters, '/')) {
                 return $parameters;
             }
 
@@ -109,7 +109,7 @@ abstract class sfWebController extends sfController
         // routeName?
         if ($url && '@' == $url[0]) {
             $route = substr($url, 1);
-        } elseif (false !== strpos($url, '/')) {
+        } elseif (str_contains($url, '/')) {
             list($params['module'], $params['action']) = explode('/', $url);
         } elseif (!$queryString) {
             $route = $givenUrl;

--- a/lib/debug/sfDebug.class.php
+++ b/lib/debug/sfDebug.class.php
@@ -238,7 +238,7 @@ class sfDebug
         }
 
         foreach (['sf_root_dir', 'sf_symfony_lib_dir'] as $key) {
-            if (0 === strpos($file, $value = sfConfig::get($key))) {
+            if (str_starts_with($file, $value = sfConfig::get($key))) {
                 $file = str_replace($value, strtoupper($key), $file);
 
                 break;

--- a/lib/debug/sfWebDebugPanel.class.php
+++ b/lib/debug/sfWebDebugPanel.class.php
@@ -115,7 +115,7 @@ abstract class sfWebDebugPanel
             $file = isset($trace['file']) ? $trace['file'] : null;
             $line = isset($trace['line']) ? $trace['line'] : null;
 
-            $isProjectFile = $file && 0 === strpos($file, sfConfig::get('sf_root_dir')) && !preg_match('/(cache|plugins|vendor)/', $file);
+            $isProjectFile = $file && str_starts_with($file, sfConfig::get('sf_root_dir')) && !preg_match('/(cache|plugins|vendor)/', $file);
 
             $html .= sprintf('<span%s>#%s &raquo; ', $isProjectFile ? ' class="sfWebDebugHighlight"' : '', $keys[$j] + 1);
 

--- a/lib/debug/sfWebDebugPanelCache.class.php
+++ b/lib/debug/sfWebDebugPanelCache.class.php
@@ -25,7 +25,7 @@ class sfWebDebugPanelCache extends sfWebDebugPanel
     {
         $queryString = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
 
-        if (false === strpos($queryString, '_sf_ignore_cache')) {
+        if (!str_contains($queryString, '_sf_ignore_cache')) {
             return sprintf('?%s_sf_ignore_cache=1', $queryString ? $queryString.'&' : '');
         }
 

--- a/lib/debug/sfWebDebugPanelLogs.class.php
+++ b/lib/debug/sfWebDebugPanelLogs.class.php
@@ -108,7 +108,7 @@ class sfWebDebugPanelLogs extends sfWebDebugPanel
         $logLine = $this->formatSql($logLine);
 
         // remove username/password from DSN
-        if (false !== strpos($logLine, 'DSN')) {
+        if (str_contains($logLine, 'DSN')) {
             $logLine = preg_replace("/=&gt;\\s+'?[^'\\s,]+'?/", "=&gt; '****'", $logLine);
         }
 

--- a/lib/debug/sfWebDebugPanelView.class.php
+++ b/lib/debug/sfWebDebugPanelView.class.php
@@ -303,7 +303,7 @@ class sfWebDebugPanelView extends sfWebDebugPanel
         $filtered = [];
 
         foreach ($parameters as $name => $value) {
-            if (0 !== strpos($name, 'sf_')) {
+            if (!str_starts_with($name, 'sf_')) {
                 $filtered[$name] = $value;
             }
         }

--- a/lib/escaper/sfOutputEscaperObjectDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperObjectDecorator.class.php
@@ -44,7 +44,7 @@ class sfOutputEscaperObjectDecorator extends sfOutputEscaperGetterDecorator impl
     {
         if (count($args) > 0) {
             $escapingMethod = $args[count($args) - 1];
-            if (is_string($escapingMethod) && 'esc_' === substr($escapingMethod, 0, 4)) {
+            if (is_string($escapingMethod) && str_starts_with($escapingMethod, 'esc_')) {
                 array_pop($args);
             } else {
                 $escapingMethod = $this->escapingMethod;

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -400,7 +400,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
      */
     public function getName()
     {
-        if ('[%s]' != substr($nameFormat = $this->widgetSchema->getNameFormat(), -4)) {
+        if (!str_ends_with($nameFormat = $this->widgetSchema->getNameFormat(), '[%s]')) {
             return false;
         }
 

--- a/lib/generator/sfModelGeneratorConfiguration.class.php
+++ b/lib/generator/sfModelGeneratorConfiguration.class.php
@@ -276,7 +276,7 @@ abstract class sfModelGeneratorConfiguration
 
     public function getCredentials($action)
     {
-        if (0 === strpos($action, '_')) {
+        if (str_starts_with($action, '_')) {
             $action = substr($action, 1);
         }
 
@@ -401,7 +401,7 @@ abstract class sfModelGeneratorConfiguration
         foreach ($this->getListBatchActions() as $action => $parameters) {
             $parameters = $this->fixActionParameters($action, $parameters);
 
-            $action = 'batch'.ucfirst(0 === strpos($action, '_') ? substr($action, 1) : $action);
+            $action = 'batch'.ucfirst(str_starts_with($action, '_') ? substr($action, 1) : $action);
 
             $this->configuration['list']['batch_actions'][$action] = $parameters;
         }
@@ -440,7 +440,7 @@ abstract class sfModelGeneratorConfiguration
             'delete' => [],
         ];
         foreach ($this->getActionsDefault() as $action => $params) {
-            if (0 === strpos($action, '_')) {
+            if (str_starts_with($action, '_')) {
                 $action = substr($action, 1);
             }
 

--- a/lib/helper/AssetHelper.php
+++ b/lib/helper/AssetHelper.php
@@ -353,13 +353,13 @@ function image_tag($source, $options = [])
 
 function _compute_public_path($source, $dir, $ext, $absolute = false)
 {
-    if (strpos($source, '://') || 0 === strpos($source, '//')) {
+    if (strpos($source, '://') || str_starts_with($source, '//')) {
         return $source;
     }
 
     $request = sfContext::getInstance()->getRequest();
     $sf_relative_url_root = $request->getRelativeUrlRoot();
-    if (0 !== strpos($source, '/')) {
+    if (!str_starts_with($source, '/')) {
         $source = $sf_relative_url_root.'/'.$dir.'/'.$source;
     }
 
@@ -369,11 +369,11 @@ function _compute_public_path($source, $dir, $ext, $absolute = false)
         $source = substr($source, 0, $pos);
     }
 
-    if (false === strpos(basename($source), '.')) {
+    if (!str_contains(basename($source), '.')) {
         $source .= '.'.$ext;
     }
 
-    if ($sf_relative_url_root && 0 !== strpos($source, $sf_relative_url_root)) {
+    if ($sf_relative_url_root && !str_starts_with($source, $sf_relative_url_root)) {
         $source = $sf_relative_url_root.$source;
     }
 
@@ -588,7 +588,7 @@ function use_dynamic_stylesheet($css, $position = '', $options = [])
 
 function _dynamic_path($uri, $format, $absolute = false)
 {
-    return url_for($uri.(false === strpos($uri, '?') ? '?' : '&').'sf_format='.$format, $absolute);
+    return url_for($uri.(!str_contains($uri, '?') ? '?' : '&').'sf_format='.$format, $absolute);
 }
 
 /**

--- a/lib/helper/TagHelper.php
+++ b/lib/helper/TagHelper.php
@@ -151,7 +151,7 @@ function _get_option(&$options, $name, $default = null)
 function get_id_from_name($name, $value = null)
 {
     // check to see if we have an array variable for a field name
-    if (false !== strpos($name, '[')) {
+    if (str_contains($name, '[')) {
         $name = str_replace(['[]', '][', '[', ']'], [(null != $value) ? '_'.$value : '', '_', '_', ''], $name);
     }
 

--- a/lib/helper/UrlHelper.php
+++ b/lib/helper/UrlHelper.php
@@ -108,7 +108,7 @@ function url_for()
 {
     // for BC with 1.1
     $arguments = func_get_args();
-    if (is_array($arguments[0]) || '@' == substr($arguments[0], 0, 1) || str_contains($arguments[0], '/')) {
+    if (is_array($arguments[0]) || str_starts_with($arguments[0], '@') || str_contains($arguments[0], '/')) {
         return call_user_func_array('url_for1', $arguments);
     }
 
@@ -156,7 +156,7 @@ function link_to()
 {
     // for BC with 1.1
     $arguments = func_get_args();
-    if (empty($arguments[1]) || is_array($arguments[1]) || '@' == substr($arguments[1], 0, 1) || str_contains($arguments[1], '/')) {
+    if (empty($arguments[1]) || is_array($arguments[1]) || str_starts_with($arguments[1], '@') || str_contains($arguments[1], '/')) {
         return call_user_func_array('link_to1', $arguments);
     }
 
@@ -215,7 +215,7 @@ function form_tag_for(sfForm $form, $routePrefix, $attributes = [])
 function link_to_if()
 {
     $arguments = func_get_args();
-    if (empty($arguments[2]) || '@' == substr($arguments[2], 0, 1) || str_contains($arguments[2], '/')) {
+    if (empty($arguments[2]) || str_starts_with($arguments[2], '@') || str_contains($arguments[2], '/')) {
         list($condition, $name, $params, $options) = array_pad($arguments, 4, null);
     } else {
         list($condition, $name, $routeName, $params, $options) = array_pad($arguments, 5, null);
@@ -294,7 +294,7 @@ function public_path($path, $absolute = false)
         $source = $root;
     }
 
-    if ('/' != substr($path, 0, 1)) {
+    if (!str_starts_with($path, '/')) {
         $path = '/'.$path;
     }
 

--- a/lib/helper/UrlHelper.php
+++ b/lib/helper/UrlHelper.php
@@ -108,7 +108,7 @@ function url_for()
 {
     // for BC with 1.1
     $arguments = func_get_args();
-    if (is_array($arguments[0]) || '@' == substr($arguments[0], 0, 1) || false !== strpos($arguments[0], '/')) {
+    if (is_array($arguments[0]) || '@' == substr($arguments[0], 0, 1) || str_contains($arguments[0], '/')) {
         return call_user_func_array('url_for1', $arguments);
     }
 
@@ -156,7 +156,7 @@ function link_to()
 {
     // for BC with 1.1
     $arguments = func_get_args();
-    if (empty($arguments[1]) || is_array($arguments[1]) || '@' == substr($arguments[1], 0, 1) || false !== strpos($arguments[1], '/')) {
+    if (empty($arguments[1]) || is_array($arguments[1]) || '@' == substr($arguments[1], 0, 1) || str_contains($arguments[1], '/')) {
         return call_user_func_array('link_to1', $arguments);
     }
 
@@ -215,7 +215,7 @@ function form_tag_for(sfForm $form, $routePrefix, $attributes = [])
 function link_to_if()
 {
     $arguments = func_get_args();
-    if (empty($arguments[2]) || '@' == substr($arguments[2], 0, 1) || false !== strpos($arguments[2], '/')) {
+    if (empty($arguments[2]) || '@' == substr($arguments[2], 0, 1) || str_contains($arguments[2], '/')) {
         list($condition, $name, $params, $options) = array_pad($arguments, 4, null);
     } else {
         list($condition, $name, $routeName, $params, $options) = array_pad($arguments, 5, null);

--- a/lib/i18n/sfI18N.class.php
+++ b/lib/i18n/sfI18N.class.php
@@ -329,7 +329,7 @@ class sfI18N
 
         // We parse time format to see where things are (h, m)
         $timePositions = [
-            'h' => false !== strpos($timeFormat, 'H') ? strpos($timeFormat, 'H') : strpos($timeFormat, 'h'),
+            'h' => str_contains($timeFormat, 'H') ? strpos($timeFormat, 'H') : strpos($timeFormat, 'h'),
             'm' => strpos($timeFormat, 'm'),
             'a' => strpos($timeFormat, 'a'),
         ];

--- a/lib/i18n/sfMessageSource_Database.class.php
+++ b/lib/i18n/sfMessageSource_Database.class.php
@@ -130,10 +130,10 @@ abstract class sfMessageSource_Database extends sfMessageSource
             $dsn = $match[3];
         // $dsn => protocol+hostspec/database (old format)
         } else {
-            if (false !== strpos($dsn, '+')) {
+            if (str_contains($dsn, '+')) {
                 list($proto, $dsn) = explode('+', $dsn, 2);
             }
-            if (false !== strpos($dsn, '/')) {
+            if (str_contains($dsn, '/')) {
                 list($proto_opts, $dsn) = explode('/', $dsn, 2);
             } else {
                 $proto_opts = $dsn;
@@ -145,7 +145,7 @@ abstract class sfMessageSource_Database extends sfMessageSource
         $parsed['protocol'] = (!empty($proto)) ? $proto : 'tcp';
         $proto_opts = rawurldecode($proto_opts);
         if ('tcp' == $parsed['protocol']) {
-            if (false !== strpos($proto_opts, ':')) {
+            if (str_contains($proto_opts, ':')) {
                 list($parsed['hostspec'], $parsed['port']) = explode(':', $proto_opts);
             } else {
                 $parsed['hostspec'] = $proto_opts;
@@ -164,7 +164,7 @@ abstract class sfMessageSource_Database extends sfMessageSource
             } else {
                 $parsed['database'] = substr($dsn, 0, $pos);
                 $dsn = substr($dsn, $pos + 1);
-                if (false !== strpos($dsn, '&')) {
+                if (str_contains($dsn, '&')) {
                     $opts = explode('&', $dsn);
                 } else { // database?param1=value1
                     $opts = [$dsn];

--- a/lib/i18n/sfNumberFormat.class.php
+++ b/lib/i18n/sfNumberFormat.class.php
@@ -296,7 +296,7 @@ class sfNumberFormat
     {
         $string = (string) $float;
 
-        if (false === strpos($float, 'E')) {
+        if (!str_contains($float, 'E')) {
             return $string;
         }
 

--- a/lib/log/sfWebDebugLogger.class.php
+++ b/lib/log/sfWebDebugLogger.class.php
@@ -150,7 +150,7 @@ class sfWebDebugLogger extends sfVarLogger
             || !$this->context->has('response')
             || !$this->context->has('controller')
             || $request->isXmlHttpRequest()
-            || false === strpos($response->getContentType(), 'html')
+            || !str_contains($response->getContentType(), 'html')
             || '3' == substr($response->getStatusCode(), 0, 1)
             || sfView::RENDER_CLIENT != $this->context->getController()->getRenderMode()
             || $response->isHeaderOnly()

--- a/lib/log/sfWebDebugLogger.class.php
+++ b/lib/log/sfWebDebugLogger.class.php
@@ -151,7 +151,7 @@ class sfWebDebugLogger extends sfVarLogger
             || !$this->context->has('controller')
             || $request->isXmlHttpRequest()
             || !str_contains($response->getContentType(), 'html')
-            || '3' == substr($response->getStatusCode(), 0, 1)
+            || str_starts_with($response->getStatusCode(), '3')
             || sfView::RENDER_CLIENT != $this->context->getController()->getRenderMode()
             || $response->isHeaderOnly()
         ) {

--- a/lib/plugin/sfPluginManager.class.php
+++ b/lib/plugin/sfPluginManager.class.php
@@ -114,7 +114,7 @@ class sfPluginManager
      */
     public function uninstallPlugin($plugin, $channel = null)
     {
-        if (false !== strpos($plugin, '/')) {
+        if (str_contains($plugin, '/')) {
             list($channel, $plugin) = explode('/', $plugin);
         }
 
@@ -293,14 +293,14 @@ class sfPluginManager
         $version = isset($options['version']) ? $options['version'] : null;
 
         $isPackage = true;
-        if (0 === strpos($plugin, 'http://') || file_exists($plugin)) {
-            if (0 === strpos($plugin, 'http://plugins.symfony-project.')) {
+        if (str_starts_with($plugin, 'http://') || file_exists($plugin)) {
+            if (str_starts_with($plugin, 'http://plugins.symfony-project.')) {
                 throw new sfPluginException("You try to install a symfony 1.0 plugin.\nPlease read the help message of this task to know how to install a plugin for the current version of symfony.");
             }
 
             $download = $plugin;
             $isPackage = false;
-        } elseif (false !== strpos($plugin, '/')) {
+        } elseif (str_contains($plugin, '/')) {
             list($channel, $plugin) = explode('/', $plugin);
         }
 

--- a/lib/plugin/sfSymfonyPluginManager.class.php
+++ b/lib/plugin/sfSymfonyPluginManager.class.php
@@ -175,9 +175,9 @@ class sfSymfonyPluginManager extends sfPluginManager
         $symfony->setConfig($this->environment->getConfig());
         $symfony->setPackageType('php');
         $symfony->setAPIVersion(preg_replace('/\d+(\-\w+)?$/', '0', SYMFONY_VERSION));
-        $symfony->setAPIStability(false === strpos(SYMFONY_VERSION, 'DEV') ? 'stable' : 'beta');
+        $symfony->setAPIStability(!str_contains(SYMFONY_VERSION, 'DEV') ? 'stable' : 'beta');
         $symfony->setReleaseVersion(preg_replace('/\-\w+$/', '', SYMFONY_VERSION));
-        $symfony->setReleaseStability(false === strpos(SYMFONY_VERSION, 'DEV') ? 'stable' : 'beta');
+        $symfony->setReleaseStability(!str_contains(SYMFONY_VERSION, 'DEV') ? 'stable' : 'beta');
         $symfony->setDate(date('Y-m-d'));
         $symfony->setDescription('symfony');
         $symfony->setSummary('symfony');

--- a/lib/plugins/sfDoctrinePlugin/lib/debug/sfWebDebugPanelDoctrine.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/debug/sfWebDebugPanelDoctrine.class.php
@@ -123,7 +123,7 @@ class sfWebDebugPanelDoctrine extends sfWebDebugPanel
                     break;
                 }
 
-                if (false !== strpos($log['message'], $event->getQuery())) {
+                if (str_contains($log['message'], $event->getQuery())) {
                     // assume queries are being requested in order
                     unset($logs[$i]);
                     $backtrace = '&nbsp;'.$this->getToggleableDebugStack($log['debug_backtrace']);

--- a/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineBaseTask.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineBaseTask.class.php
@@ -140,7 +140,7 @@ abstract class sfDoctrineBaseTask extends sfBaseTask
                         $models[$model]['package'] = $plugin->getName().'.lib.model.doctrine';
                     }
 
-                    if (!isset($models[$model]['package_custom_path']) && 0 === strpos($models[$model]['package'], $plugin->getName())) {
+                    if (!isset($models[$model]['package_custom_path']) && str_starts_with($models[$model]['package'], $plugin->getName())) {
                         $models[$model]['package_custom_path'] = $plugin->getRootDir().'/lib/model/doctrine';
                     }
                 }

--- a/lib/plugins/sfDoctrinePlugin/lib/test/sfTesterDoctrine.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/test/sfTesterDoctrine.class.php
@@ -61,7 +61,7 @@ class sfTesterDoctrine extends sfTester
                 }
 
                 $operator = '=';
-                if (strlen($condition) && '!' == substr($condition, 0, 1)) {
+                if (strlen($condition) && str_starts_with($condition, '!')) {
                     $operator = str_contains($condition, '%') ? 'NOT LIKE' : '!=';
                     $condition = substr($condition, 1);
                 } elseif (str_contains($condition, '%')) {

--- a/lib/plugins/sfDoctrinePlugin/lib/test/sfTesterDoctrine.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/test/sfTesterDoctrine.class.php
@@ -62,9 +62,9 @@ class sfTesterDoctrine extends sfTester
 
                 $operator = '=';
                 if (strlen($condition) && '!' == substr($condition, 0, 1)) {
-                    $operator = false !== strpos($condition, '%') ? 'NOT LIKE' : '!=';
+                    $operator = str_contains($condition, '%') ? 'NOT LIKE' : '!=';
                     $condition = substr($condition, 1);
-                } elseif (false !== strpos($condition, '%')) {
+                } elseif (str_contains($condition, '%')) {
                     $operator = 'LIKE';
                 }
 

--- a/lib/plugins/sfDoctrinePlugin/test/functional/AdminGenBrowser.class.php
+++ b/lib/plugins/sfDoctrinePlugin/test/functional/AdminGenBrowser.class.php
@@ -26,7 +26,7 @@ class AdminGenBrowser extends sfTestBrowser
 
         $methods = get_class_methods($this);
         foreach ($methods as $method) {
-            if ('_test' == substr($method, 0, 5)) {
+            if (str_starts_with($method, '_test')) {
                 $this->{$method}();
             }
         }

--- a/lib/plugins/sfDoctrinePlugin/test/functional/AdminGenBrowser.class.php
+++ b/lib/plugins/sfDoctrinePlugin/test/functional/AdminGenBrowser.class.php
@@ -40,7 +40,7 @@ class AdminGenBrowser extends sfTestBrowser
 
         $matches = 0;
         foreach ($this->_getQueryExecutionEvents() as $event) {
-            if (false !== strpos($event->getQuery(), 'ORDER BY u.username asc')) {
+            if (str_contains($event->getQuery(), 'ORDER BY u.username asc')) {
                 ++$matches;
             }
         }
@@ -69,7 +69,7 @@ class AdminGenBrowser extends sfTestBrowser
 
             $matches = 0;
             foreach ($this->_getQueryExecutionEvents() as $event) {
-                if (false !== strpos($event->getQuery(), 'ORDER BY u.username '.$sortType)) {
+                if (str_contains($event->getQuery(), 'ORDER BY u.username '.$sortType)) {
                     ++$matches;
                 }
             }

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -199,7 +199,7 @@ class sfWebRequest extends sfRequest
     {
         $pathArray = $this->getPathInfoArray();
 
-        return isset($pathArray['REQUEST_URI']) ? 0 === strpos($pathArray['REQUEST_URI'], 'http') : false;
+        return isset($pathArray['REQUEST_URI']) ? str_starts_with($pathArray['REQUEST_URI'], 'http') : false;
     }
 
     /**
@@ -217,7 +217,7 @@ class sfWebRequest extends sfRequest
         $port = null;
 
         // extract port from host or environment variable
-        if (false !== strpos($host, ':')) {
+        if (str_contains($host, ':')) {
             list($host, $port) = explode(':', $host, 2);
         } elseif ($protocolPort = $this->getOption($protocol.'_port')) {
             $port = $protocolPort;
@@ -432,7 +432,7 @@ class sfWebRequest extends sfRequest
 
         $languages = $this->splitHttpAcceptHeader($_SERVER['HTTP_ACCEPT_LANGUAGE']);
         foreach ($languages as $lang) {
-            if (false !== strpos($lang, '-')) {
+            if (str_contains($lang, '-')) {
                 $codes = explode('-', $lang);
                 if ('i' == $codes[0]) {
                     // Language not listed in ISO 639 that are not variants

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -332,7 +332,7 @@ class sfWebResponse extends sfResponse
         $status = $this->options['http_protocol'].' '.$this->statusCode.' '.$this->statusText;
         header($status);
 
-        if ('cgi' == substr(php_sapi_name(), 0, 3)) {
+        if (str_starts_with(php_sapi_name(), 'cgi')) {
             // fastcgi servers cannot send this status information because it was sent by them already due to the HTT/1.0 line
             // so we can safely unset them. see ticket #3191
             unset($this->headers['Status']);

--- a/lib/routing/sfObjectRoute.class.php
+++ b/lib/routing/sfObjectRoute.class.php
@@ -209,7 +209,7 @@ class sfObjectRoute extends sfRequestRoute
         $variables = [];
 
         foreach (array_keys($this->variables) as $variable) {
-            if (0 === strpos($variable, 'sf_') || in_array($variable, ['module', 'action'])) {
+            if (str_starts_with($variable, 'sf_') || in_array($variable, ['module', 'action'])) {
                 continue;
             }
 

--- a/lib/routing/sfPatternRouting.class.php
+++ b/lib/routing/sfPatternRouting.class.php
@@ -500,7 +500,7 @@ class sfPatternRouting extends sfRouting
     protected function normalizeUrl($url)
     {
         // an URL should start with a '/', mod_rewrite doesn't respect that, but no-mod_rewrite version does.
-        if ('/' != substr($url, 0, 1)) {
+        if (!str_starts_with($url, '/')) {
             $url = '/'.$url;
         }
 

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -122,7 +122,7 @@ class sfRoute implements Serializable
         }
 
         // check the static prefix uf the URL first. Only use the more expensive preg_match when it matches
-        if ('' !== $this->staticPrefix && 0 !== strpos($url, $this->staticPrefix)) {
+        if ('' !== $this->staticPrefix && !str_starts_with($url, $this->staticPrefix)) {
             return false;
         }
         if (!preg_match($this->regex, $url, $matches)) {
@@ -190,7 +190,7 @@ class sfRoute implements Serializable
 
         // all $params must be in $variables or $defaults if there is no * in route
         if (!$this->options['extra_parameters_as_query_string']) {
-            if (false === strpos($this->regex, '<_star>') && array_diff_key($params, $this->variables, $defaults)) {
+            if (!str_contains($this->regex, '<_star>') && array_diff_key($params, $this->variables, $defaults)) {
                 return false;
             }
         }
@@ -699,12 +699,12 @@ class sfRoute implements Serializable
 
     protected function hasStarParameter()
     {
-        return false !== strpos($this->regex, '<_star>');
+        return str_contains($this->regex, '<_star>');
     }
 
     protected function generateStarParameter($url, $defaults, $parameters)
     {
-        if (false === strpos($this->regex, '<_star>')) {
+        if (!str_contains($this->regex, '<_star>')) {
             return $url;
         }
 

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -756,7 +756,7 @@ class sfRoute implements Serializable
             if ('^' == $regex[0]) {
                 $regex = substr($regex, 1);
             }
-            if ('$' == substr($regex, -1)) {
+            if (str_ends_with($regex, '$')) {
                 $regex = substr($regex, 0, -1);
             }
 

--- a/lib/routing/sfRouting.class.php
+++ b/lib/routing/sfRouting.class.php
@@ -266,14 +266,14 @@ abstract class sfRouting
     protected function fixGeneratedUrl($url, $absolute = false)
     {
         if (isset($this->options['context']['prefix'])) {
-            if (0 === strpos($url, 'http')) {
+            if (str_starts_with($url, 'http')) {
                 $url = preg_replace('#https?\://[^/]+#', '$0'.$this->options['context']['prefix'], $url);
             } else {
                 $url = $this->options['context']['prefix'].$url;
             }
         }
 
-        if ($absolute && isset($this->options['context']['host']) && 0 !== strpos($url, 'http')) {
+        if ($absolute && isset($this->options['context']['host']) && !str_starts_with($url, 'http')) {
             $url = 'http'.(isset($this->options['context']['is_secure']) && $this->options['context']['is_secure'] ? 's' : '').'://'.$this->options['context']['host'].$url;
         }
 

--- a/lib/service/sfServiceContainerLoaderArray.class.php
+++ b/lib/service/sfServiceContainerLoaderArray.class.php
@@ -58,7 +58,7 @@ class sfServiceContainerLoaderArray extends sfServiceContainerLoader
 
     protected function parseDefinition($service)
     {
-        if (is_string($service) && 0 === strpos($service, '@')) {
+        if (is_string($service) && str_starts_with($service, '@')) {
             return substr($service, 1);
         }
 
@@ -101,7 +101,7 @@ class sfServiceContainerLoaderArray extends sfServiceContainerLoader
     {
         if (is_array($value)) {
             $value = array_map([$this, 'resolveServices'], $value);
-        } elseif (is_string($value) && 0 === strpos($value, '@')) {
+        } elseif (is_string($value) && str_starts_with($value, '@')) {
             $value = new sfServiceReference(substr($value, 1));
         }
 

--- a/lib/storage/sfCacheSessionStorage.class.php
+++ b/lib/storage/sfCacheSessionStorage.class.php
@@ -82,7 +82,7 @@ class sfCacheSessionStorage extends sfStorage
 
         $cookie = $this->request->getCookie($this->options['session_name']);
 
-        if (null !== $cookie && false !== strpos($cookie, ':')) {
+        if (null !== $cookie && str_contains($cookie, ':')) {
             // split cookie data id:signature(id+secret)
             list($id, $signature) = explode(':', $cookie, 2);
 

--- a/lib/task/generator/sfGenerateProjectTask.class.php
+++ b/lib/task/generator/sfGenerateProjectTask.class.php
@@ -101,7 +101,7 @@ EOF;
         $this->installDir(__DIR__.'/skeleton/project');
 
         // update ProjectConfiguration class (use a relative path when the symfony core is nested within the project)
-        $symfonyCoreAutoload = 0 === strpos(sfConfig::get('sf_symfony_lib_dir'), sfConfig::get('sf_root_dir')) ?
+        $symfonyCoreAutoload = str_starts_with(sfConfig::get('sf_symfony_lib_dir'), sfConfig::get('sf_root_dir')) ?
           sprintf('__DIR__.\'/..%s/autoload/sfCoreAutoload.class.php\'', str_replace(sfConfig::get('sf_root_dir'), '', sfConfig::get('sf_symfony_lib_dir'))) :
           var_export(sfConfig::get('sf_symfony_lib_dir').'/autoload/sfCoreAutoload.class.php', true);
 

--- a/lib/task/project/sfProjectDeployTask.class.php
+++ b/lib/task/project/sfProjectDeployTask.class.php
@@ -136,7 +136,7 @@ EOF;
         $dir = $properties['dir'];
         $user = isset($properties['user']) ? $properties['user'].'@' : '';
 
-        if ('/' != substr($dir, -1)) {
+        if (!str_ends_with($dir, '/')) {
             $dir .= '/';
         }
 

--- a/lib/task/project/validation/sfDeprecatedConfigurationFilesValidation.class.php
+++ b/lib/task/project/validation/sfDeprecatedConfigurationFilesValidation.class.php
@@ -57,7 +57,7 @@ class sfDeprecatedConfigurationFilesValidation extends sfValidation
         foreach ($files as $file) {
             $content = file_get_contents($file);
 
-            if (false !== strpos($content, 'sfPropelAdminGenerator')) {
+            if (str_contains($content, 'sfPropelAdminGenerator')) {
                 $found[$file] = true;
             }
         }

--- a/lib/task/project/validation/sfDeprecatedPluginsValidation.class.php
+++ b/lib/task/project/validation/sfDeprecatedPluginsValidation.class.php
@@ -40,10 +40,10 @@ class sfDeprecatedPluginsValidation extends sfValidation
             $content = sfToolkit::stripComments(file_get_contents($file));
 
             $matches = [];
-            if (false !== strpos($content, 'sfCompat10Plugin')) {
+            if (str_contains($content, 'sfCompat10Plugin')) {
                 $matches[] = 'sfCompat10Plugin';
             }
-            if (false !== strpos($content, 'sfProtoculousPlugin')) {
+            if (str_contains($content, 'sfProtoculousPlugin')) {
                 $matches[] = 'sfProtoculousPlugin';
             }
 

--- a/lib/task/sfTask.class.php
+++ b/lib/task/sfTask.class.php
@@ -253,7 +253,7 @@ abstract class sfTask
 
         $name = get_class($this);
 
-        if ('sf' == substr($name, 0, 2)) {
+        if (str_starts_with($name, 'sf')) {
             $name = substr($name, 2);
         }
 

--- a/lib/task/sfTask.class.php
+++ b/lib/task/sfTask.class.php
@@ -257,7 +257,7 @@ abstract class sfTask
             $name = substr($name, 2);
         }
 
-        if ('Task' == substr($name, -4)) {
+        if (str_ends_with($name, 'Task')) {
             $name = substr($name, 0, -4);
         }
 

--- a/lib/task/sfTask.class.php
+++ b/lib/task/sfTask.class.php
@@ -144,7 +144,7 @@ abstract class sfTask
             }
 
             // add -- before each option if needed
-            if (0 !== strpos($value, '--')) {
+            if (!str_starts_with($value, '--')) {
                 $value = '--'.$value;
             }
 

--- a/lib/test/sfTesterViewCache.class.php
+++ b/lib/test/sfTesterViewCache.class.php
@@ -101,7 +101,7 @@ class sfTesterViewCache extends sfTester
                 } else {
                     $ret = unserialize($cacheManager->get($uri));
                     $content = $ret['content'];
-                    $this->tester->ok(false !== strpos($this->response->getContent(), $content), 'content in cache is ok');
+                    $this->tester->ok(str_contains($this->response->getContent(), $content), 'content in cache is ok');
                 }
             }
         }

--- a/lib/util/sfBrowserBase.class.php
+++ b/lib/util/sfBrowserBase.class.php
@@ -636,7 +636,7 @@ abstract class sfBrowserBase
      */
     public function doClick($name, $arguments = [], $options = [])
     {
-        if (false !== strpos($name, '[') || false !== strpos($name, ']')) {
+        if (str_contains($name, '[') || str_contains($name, ']')) {
             throw new InvalidArgumentException(sprintf('The name "%s" is not valid', $name));
         }
 
@@ -812,7 +812,7 @@ abstract class sfBrowserBase
         }
 
         $queryString = is_array($arguments) ? http_build_query($arguments, '', '&') : '';
-        $sep = false === strpos($url, '?') ? '?' : '&';
+        $sep = !str_contains($url, '?') ? '?' : '&';
 
         return [$url.($queryString ? $sep.$queryString : ''), 'get', []];
     }
@@ -853,9 +853,9 @@ abstract class sfBrowserBase
     public function fixUri($uri)
     {
         // remove absolute information if needed (to be able to do follow redirects, click on links, ...)
-        if (0 === strpos($uri, 'http')) {
+        if (str_starts_with($uri, 'http')) {
             // detect secure request
-            if (0 === strpos($uri, 'https')) {
+            if (str_starts_with($uri, 'https')) {
                 $this->defaultServerArray['HTTPS'] = 'on';
             } else {
                 unset($this->defaultServerArray['HTTPS']);

--- a/lib/util/sfBrowserBase.class.php
+++ b/lib/util/sfBrowserBase.class.php
@@ -893,7 +893,7 @@ abstract class sfBrowserBase
             foreach ($tmps as $tmp) {
                 $var = &$var[$tmp];
             }
-            if ($var && '[]' === substr($name, -2)) {
+            if ($var && str_ends_with($name, '[]')) {
                 if (!is_array($var)) {
                     $var = [$var];
                 }

--- a/lib/util/sfDomCssSelector.class.php
+++ b/lib/util/sfDomCssSelector.class.php
@@ -259,7 +259,7 @@ class sfDomCssSelector implements Countable, Iterator
                                     break;
 
                                 case '$': // Match ends with value
-                                    $ok = $attrValue == substr($found->getAttribute($attrName), -strlen($attrValue));
+                                    $ok = str_ends_with($found->getAttribute($attrName), $attrValue);
 
                                     break;
 

--- a/lib/util/sfDomCssSelector.class.php
+++ b/lib/util/sfDomCssSelector.class.php
@@ -254,7 +254,7 @@ class sfDomCssSelector implements Countable, Iterator
                                     break;
 
                                 case '^': // Match starts with value
-                                    $ok = 0 === strpos($found->getAttribute($attrName), $attrValue);
+                                    $ok = str_starts_with($found->getAttribute($attrName), $attrValue);
 
                                     break;
 
@@ -264,7 +264,7 @@ class sfDomCssSelector implements Countable, Iterator
                                     break;
 
                                 case '*': // Match ends with value
-                                    $ok = false !== strpos($found->getAttribute($attrName), $attrValue);
+                                    $ok = str_contains($found->getAttribute($attrName), $attrValue);
 
                                     break;
 
@@ -458,7 +458,7 @@ class sfDomCssSelector implements Countable, Iterator
         for ($i = 0, $max = count($nodes); $i < $max; ++$i) {
             switch ($selector['selector']) {
                 case 'contains':
-                    if (false !== strpos($nodes[$i]->textContent, $selector['parameter'])) {
+                    if (str_contains($nodes[$i]->textContent, $selector['parameter'])) {
                         $matchingNodes[] = $nodes[$i];
                     }
 

--- a/lib/util/sfFinder.class.php
+++ b/lib/util/sfFinder.class.php
@@ -100,7 +100,7 @@ class sfFinder
     {
         $name = strtolower($name);
 
-        if ('dir' === substr($name, 0, 3)) {
+        if (str_starts_with($name, 'dir')) {
             $this->type = 'directory';
 
             return $this;

--- a/lib/util/sfInflector.class.php
+++ b/lib/util/sfInflector.class.php
@@ -103,7 +103,7 @@ class sfInflector
      */
     public static function humanize($lower_case_and_underscored_word)
     {
-        if ('_id' === substr($lower_case_and_underscored_word, -3)) {
+        if (str_ends_with($lower_case_and_underscored_word, '_id')) {
             $lower_case_and_underscored_word = substr($lower_case_and_underscored_word, 0, -3);
         }
 

--- a/lib/validator/sfValidatorFile.class.php
+++ b/lib/validator/sfValidatorFile.class.php
@@ -236,7 +236,7 @@ class sfValidatorFile extends sfValidatorBase
         ob_start();
         // need to use --mime instead of -i. see #6641
         $cmd = 'file -b --mime -- %s 2>/dev/null';
-        $file = (0 === strpos($file, '-') ? './' : '').$file;
+        $file = (str_starts_with($file, '-') ? './' : '').$file;
         passthru(sprintf($cmd, escapeshellarg($file)), $return);
         if ($return > 0) {
             ob_end_clean();

--- a/lib/vendor/lime/lime.php
+++ b/lib/vendor/lime/lime.php
@@ -179,7 +179,7 @@ class lime_test
     }
     $this->results['tests'][$this->test_nb]['message'] = $message;
     $this->results['tests'][$this->test_nb]['status'] = $result;
-    $this->output->echoln(sprintf("%s %d%s", $result ? 'ok' : 'not ok', $this->test_nb, $message = $message ? sprintf('%s %s', 0 === strpos($message, '#') ? '' : ' -', $message) : ''));
+    $this->output->echoln(sprintf("%s %d%s", $result ? 'ok' : 'not ok', $this->test_nb, $message = $message ? sprintf('%s %s', str_starts_with($message, '#') ? '' : ' -', $message) : ''));
 
     if (!$result)
     {

--- a/lib/view/sfViewCacheManager.class.php
+++ b/lib/view/sfViewCacheManager.class.php
@@ -124,7 +124,7 @@ class sfViewCacheManager
             return call_user_func($callable, $internalUri, $hostName, $vary, $contextualPrefix, $this);
         }
 
-        if (0 === strpos($internalUri, '@') && false === strpos($internalUri, '@sf_cache_partial')) {
+        if (str_starts_with($internalUri, '@') && !str_contains($internalUri, '@sf_cache_partial')) {
             throw new sfException('A cache key cannot be generated for an internal URI using the @rule syntax');
         }
 
@@ -167,12 +167,12 @@ class sfViewCacheManager
         }
 
         // normalize to a leading slash
-        if (0 !== strpos($cacheKey, '/')) {
+        if (!str_starts_with($cacheKey, '/')) {
             $cacheKey = '/'.$cacheKey;
         }
 
         // distinguish multiple slashes
-        while (false !== strpos($cacheKey, '//')) {
+        while (str_contains($cacheKey, '//')) {
             $cacheKey = str_replace('//', '/'.substr(sha1($cacheKey), 0, 7).'/', $cacheKey);
         }
 
@@ -795,7 +795,7 @@ class sfViewCacheManager
         $cacheKey = $this->routing->getCurrentInternalUri();
 
         if ($getParameters = $this->request->getGetParameters()) {
-            $cacheKey .= false === strpos((string) $cacheKey, '?') ? '?' : '&';
+            $cacheKey .= !str_contains((string) $cacheKey, '?') ? '?' : '&';
             $cacheKey .= http_build_query($getParameters, '', '&');
         }
 
@@ -813,7 +813,7 @@ class sfViewCacheManager
     public function decorateContentWithDebug(sfEvent $event, $content)
     {
         // don't decorate if not html or if content is null
-        if (!$content || false === strpos($event['response']->getContentType(), 'html')) {
+        if (!$content || !str_contains($event['response']->getContentType(), 'html')) {
             return $content;
         }
 

--- a/lib/widget/sfWidgetForm.class.php
+++ b/lib/widget/sfWidgetForm.class.php
@@ -219,11 +219,11 @@ abstract class sfWidgetForm extends sfWidget
         }
 
         // check to see if we have an array variable for a field name
-        if (false !== strpos($name, '[')) {
+        if (str_contains($name, '[')) {
             $name = str_replace(['[]', '][', '[', ']'], [null !== $value && !is_array($value) ? '_'.$value : '', '_', '_', ''], $name);
         }
 
-        if (false !== strpos($this->getOption('id_format'), '%s')) {
+        if (str_contains($this->getOption('id_format'), '%s')) {
             $name = sprintf($this->getOption('id_format'), $name);
         }
 

--- a/lib/widget/sfWidgetFormChoice.class.php
+++ b/lib/widget/sfWidgetFormChoice.class.php
@@ -47,7 +47,7 @@ class sfWidgetFormChoice extends sfWidgetFormChoiceBase
         if ($this->getOption('multiple')) {
             $attributes['multiple'] = 'multiple';
 
-            if ('[]' != substr($name, -2)) {
+            if (!str_ends_with($name, '[]')) {
                 $name .= '[]';
             }
         }

--- a/lib/widget/sfWidgetFormInputFileEditable.class.php
+++ b/lib/widget/sfWidgetFormInputFileEditable.class.php
@@ -37,7 +37,7 @@ class sfWidgetFormInputFileEditable extends sfWidgetFormInputFile
         }
 
         if ($this->getOption('with_delete')) {
-            $deleteName = ']' == substr($name, -1) ? substr($name, 0, -1).'_delete]' : $name.'_delete';
+            $deleteName = str_ends_with($name, ']') ? substr($name, 0, -1).'_delete]' : $name.'_delete';
 
             $delete = $this->renderTag('input', array_merge(['type' => 'checkbox', 'name' => $deleteName], $attributes));
             $deleteLabel = $this->translate($this->getOption('delete_label'));

--- a/lib/widget/sfWidgetFormSchema.class.php
+++ b/lib/widget/sfWidgetFormSchema.class.php
@@ -262,7 +262,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
      */
     public function setNameFormat($format)
     {
-        if (false !== $format && false === strpos($format, '%s')) {
+        if (false !== $format && !str_contains($format, '%s')) {
             throw new InvalidArgumentException(sprintf('The name format must contain %%s ("%s" given)', $format));
         }
 

--- a/lib/widget/sfWidgetFormSchema.class.php
+++ b/lib/widget/sfWidgetFormSchema.class.php
@@ -599,7 +599,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
     {
         $format = $this->getNameFormat();
 
-        if ('[%s]' == substr($format, -4) && preg_match('/^(.+?)\[(.+)\]$/', $name, $match)) {
+        if (str_ends_with($format, '[%s]') && preg_match('/^(.+?)\[(.+)\]$/', $name, $match)) {
             $name = sprintf('%s[%s][%s]', substr($format, 0, -4), $match[1], $match[2]);
         } elseif (false !== $format) {
             $name = sprintf($format, $name);

--- a/lib/widget/sfWidgetFormSchemaFormatter.class.php
+++ b/lib/widget/sfWidgetFormSchemaFormatter.class.php
@@ -168,7 +168,7 @@ abstract class sfWidgetFormSchemaFormatter
         $label = $this->widgetSchema->getLabel($name);
 
         if (!$label && false !== $label) {
-            $label = str_replace('_', ' ', ucfirst('_id' == substr($name, -3) ? substr($name, 0, -3) : $name));
+            $label = str_replace('_', ' ', ucfirst(str_ends_with($name, '_id') ? substr($name, 0, -3) : $name));
         }
 
         return $this->translate($label);

--- a/lib/widget/sfWidgetFormSelect.class.php
+++ b/lib/widget/sfWidgetFormSelect.class.php
@@ -32,7 +32,7 @@ class sfWidgetFormSelect extends sfWidgetFormChoiceBase
         if ($this->getOption('multiple')) {
             $attributes['multiple'] = 'multiple';
 
-            if ('[]' != substr($name, -2)) {
+            if (!str_ends_with($name, '[]')) {
                 $name .= '[]';
             }
         }

--- a/lib/widget/sfWidgetFormSelectCheckbox.class.php
+++ b/lib/widget/sfWidgetFormSelectCheckbox.class.php
@@ -29,7 +29,7 @@ class sfWidgetFormSelectCheckbox extends sfWidgetFormChoiceBase
      */
     public function render($name, $value = null, $attributes = [], $errors = [])
     {
-        if ('[]' != substr($name, -2)) {
+        if (!str_ends_with($name, '[]')) {
             $name .= '[]';
         }
 

--- a/lib/widget/sfWidgetFormSelectRadio.class.php
+++ b/lib/widget/sfWidgetFormSelectRadio.class.php
@@ -29,7 +29,7 @@ class sfWidgetFormSelectRadio extends sfWidgetFormChoiceBase
      */
     public function render($name, $value = null, $attributes = [], $errors = [])
     {
-        if ('[]' != substr($name, -2)) {
+        if (!str_ends_with($name, '[]')) {
             $name .= '[]';
         }
 

--- a/lib/yaml/sfYaml.class.php
+++ b/lib/yaml/sfYaml.class.php
@@ -64,7 +64,7 @@ class sfYaml
         $file = '';
 
         // if input is a file, process it
-        if (false === strpos($input, "\n") && is_file($input)) {
+        if (!str_contains($input, "\n") && is_file($input)) {
             $file = $input;
 
             ob_start();

--- a/lib/yaml/sfYamlInline.class.php
+++ b/lib/yaml/sfYamlInline.class.php
@@ -101,7 +101,7 @@ class sfYamlInline
             case is_numeric($value) && false === strpbrk($value, "\f\n\r\t\v"):
                 return is_infinite($value) ? str_ireplace('INF', '.Inf', (string) $value) : (is_string($value) ? "'{$value}'" : $value);
 
-            case false !== strpos($value, "\n") || false !== strpos($value, "\r"):
+            case str_contains($value, "\n") || str_contains($value, "\r"):
                 return sprintf('"%s"', str_replace(['"', "\n", "\r"], ['\\"', '\n', '\r'], $value));
 
             case preg_match('/[ \s \' " \: \{ \} \[ \] , & \* \# \?] | \A[ - ? | < > = ! % @ ` ]/x', $value):
@@ -265,7 +265,7 @@ class sfYamlInline
                     $isQuoted = in_array($sequence[$i], ['"', "'"]);
                     $value = self::parseScalar($sequence, [',', ']'], ['"', "'"], $i);
 
-                    if (!$isQuoted && false !== strpos((string) $value, ': ')) {
+                    if (!$isQuoted && str_contains((string) $value, ': ')) {
                         // embedded mapping?
                         try {
                             $value = self::parseMapping('{'.$value.'}');
@@ -378,13 +378,13 @@ class sfYamlInline
             case '~' == $scalar:
                 return null;
 
-            case 0 === strpos($scalar, '!str'):
+            case str_starts_with($scalar, '!str'):
                 return (string) substr($scalar, 5);
 
-            case 0 === strpos($scalar, '! '):
+            case str_starts_with($scalar, '! '):
                 return (int) self::parseScalar(substr($scalar, 2));
 
-            case 0 === strpos($scalar, '!!php/object:'):
+            case str_starts_with($scalar, '!!php/object:'):
                 return unserialize(substr($scalar, 13));
 
             case ctype_digit($scalar):
@@ -399,7 +399,7 @@ class sfYamlInline
             case in_array(strtolower($scalar), $falseValues):
                 return false;
 
-            case 0 === strpos($scalar, '0x'):
+            case str_starts_with($scalar, '0x'):
                 return hexdec($scalar);
 
             case is_numeric($scalar):

--- a/lib/yaml/sfYamlParser.class.php
+++ b/lib/yaml/sfYamlParser.class.php
@@ -78,7 +78,7 @@ class sfYamlParser
                 }
 
                 // array
-                if (!isset($values['value']) || '' == trim($values['value'], ' ') || 0 === strpos(ltrim($values['value'], ' '), '#')) {
+                if (!isset($values['value']) || '' == trim($values['value'], ' ') || str_starts_with(ltrim($values['value'], ' '), '#')) {
                     $c = $this->getRealCurrentLineNb() + 1;
                     $parser = new sfYamlParser($c);
                     $parser->refs = &$this->refs;
@@ -151,7 +151,7 @@ class sfYamlParser
                     $data = $isProcessed;
                 }
                 // hash
-                elseif (!isset($values['value']) || '' == trim($values['value'], ' ') || 0 === strpos(ltrim($values['value'], ' '), '#')) {
+                elseif (!isset($values['value']) || '' == trim($values['value'], ' ') || str_starts_with(ltrim($values['value'], ' '), '#')) {
                     // if next line is less indented or equal, then it means that the current value is null
                     if ($this->isNextLineIndented()) {
                         $data[$key] = null;

--- a/lib/yaml/sfYamlParser.class.php
+++ b/lib/yaml/sfYamlParser.class.php
@@ -106,7 +106,7 @@ class sfYamlParser
                 $key = sfYamlInline::parseScalar($values['key']);
 
                 if ('<<' === $key) {
-                    if (isset($values['value']) && '*' === substr($values['value'], 0, 1)) {
+                    if (isset($values['value']) && str_starts_with($values['value'], '*')) {
                         $isInPlace = substr($values['value'], 1);
                         if (!array_key_exists($isInPlace, $this->refs)) {
                             throw new InvalidArgumentException(sprintf('Reference "%s" does not exist at line %s (%s).', $isInPlace, $this->getRealCurrentLineNb() + 1, $this->currentLine));
@@ -174,7 +174,7 @@ class sfYamlParser
                     $value = sfYamlInline::load($this->lines[0]);
                     if (is_array($value)) {
                         $first = reset($value);
-                        if ('*' === substr($first, 0, 1)) {
+                        if (str_starts_with($first, '*')) {
                             $data = [];
                             foreach ($value as $alias) {
                                 $data[] = $this->refs[substr($alias, 1)];
@@ -337,7 +337,7 @@ class sfYamlParser
      */
     protected function parseValue($value)
     {
-        if ('*' === substr($value, 0, 1)) {
+        if (str_starts_with($value, '*')) {
             if (false !== $pos = strpos($value, '#')) {
                 $value = substr($value, 1, $pos - 2);
             } else {

--- a/test/unit/config/sfCompileConfigHandlerTest.php
+++ b/test/unit/config/sfCompileConfigHandlerTest.php
@@ -21,8 +21,8 @@ $t->diag('execute');
 
 sfConfig::set('sf_debug', true);
 $data = $handler->execute([$dir.'simple.yml']);
-$t->ok(false !== strpos($data, "class sfInflector\n{\n    /**"), '->execute() return complete classe codes');
+$t->ok(str_contains($data, "class sfInflector\n{\n    /**"), '->execute() return complete classe codes');
 
 sfConfig::set('sf_debug', false);
 $data = $handler->execute([$dir.'simple.yml']);
-$t->ok(false !== strpos($data, "class sfInflector\n{\n    public"), '->execute() return minified classe codes');
+$t->ok(str_contains($data, "class sfInflector\n{\n    public"), '->execute() return minified classe codes');


### PR DESCRIPTION
This PR is introduce the `str_starts_with` `str_ends_with` `str_contains` functions where is possible.
It improves code readability and also php8 or above cause an improvement in performance.

Mostly automated fixes are done using Rector and php-cs-fixer. Relevant rector rules:
- \Rector\Php80\Rector\Identical\StrEndsWithRector
- \Rector\Php80\Rector\NotIdentical\StrContainsRector
- \Rector\Php80\Rector\Identical\StrStartsWithRector

For php 7.4 `symfony/polyfill-php80` provides backwards compatibility.

Template for rector:
```php
<?php

use Rector\Config\RectorConfig;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->paths([
        __DIR__.'/lib',
        __DIR__.'/test',
    ]);
    $rectorConfig->skip([
        __DIR__.'/lib/*/skeleton/*',
    ]);
```