### PR TITLE
[command] allow to call symfony command from anywhere

### DIFF
--- a/lib/task/sfBaseTask.class.php
+++ b/lib/task/sfBaseTask.class.php
@@ -108,8 +108,6 @@ abstract class sfBaseTask extends sfCommandApplicationTask
             return $event->getReturnValue();
         }
 
-        $this->checkProjectExists();
-
         $requiresApplication = $commandManager->getArgumentSet()->hasArgument('application') || $commandManager->getOptionSet()->hasOption('application');
         if (null === $this->configuration || ($requiresApplication && !$this->configuration instanceof sfApplicationConfiguration)) {
             $application = $commandManager->getArgumentSet()->hasArgument('application') ? $commandManager->getArgumentValue('application') : ($commandManager->getOptionSet()->hasOption('application') ? $commandManager->getOptionValue('application') : null);


### PR DESCRIPTION
closes #204 

What this cause?
a) cwd is set properly => nothing
b) cwd is not set properly => somewhere something cause error

But it's the caller's responsibility to make sure cwd is set properly.
The symfony command sets cwd anyway:
https://github.com/FriendsOfSymfony1/symfony1/blob/0c9ba112fc2d7ed21796079fb66c5e592943c701/lib/task/generator/skeleton/project/symfony#L12