### PR TITLE
Fix stack trace code preview in debug screen

### DIFF
--- a/lib/exception/sfException.class.php
+++ b/lib/exception/sfException.class.php
@@ -329,7 +329,10 @@ class sfException extends Exception
         }
 
         if (is_readable($file)) {
-            $content = preg_split('#<br />#', preg_replace('/^<code>(.*)<\/code>$/s', '$1', highlight_file($file, true)));
+            $replaceRegex = '/^(?:<pre><code(?: [^>]+)?>|<code><span(?: [^>]+)?>\s*)(.*?)(?:<\/code><\/pre>|\s*<\/span>\s*<\/code>)$/s';
+            $splitRegex = '/(\r\n|\n|\r|<br \/>)/';
+
+            $content = preg_split($splitRegex, preg_replace($replaceRegex, '$1', highlight_file($file, true)));
 
             $lines = [];
             for ($i = max($line - 3, 1), $max = min($line + 3, count($content)); $i <= $max; ++$i) {


### PR DESCRIPTION
Due to a change in the output of the [highlight_file](https://www.php.net/manual/en/function.highlight-file.php) function in PHP 8.3, when working with debugging enabled, the code preview is not displayed.

![Screenshot 2024-08-12 000559](https://github.com/user-attachments/assets/9614d532-85c0-4d8b-a987-217205869668)

This PR aims to work with both 8.3 and <8.3 output, [here some quick test.](https://3v4l.org/Wlrcv) Before, the function used `<br />` :

```html
<code><span style...>
<span>code</span><br /><span>code</span><br /><span>code</span>
</span>
</code>
```

Now it uses break lines:

```html
<pre><code style...>
  <span>code</span>
  <span>code</span>
  <span>code</span>
</code></pre>
```