### PR TITLE
Add HTTP status code 308 "Permanent Redirect"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ xx/xx/xxxx: Version 1.5.xx
 * Remove sfEAcceleratorCache as the extension is not available on PHP v7.4 anymore.
 * Remove sfAPCCache as it uses the `apc` extension, which is not available on PHP v7.4 anymore.  
   **[BC-Break]** Use `sfAPCuCache` class instead, available from Symfony1 v1.5.16
+* Add support for HTTP Status Code 308 "Permanent Redirect" in `sfWebController::redirect()` method.
 
 28/02/2024: Version 1.5.18
 --------------------------

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -53,6 +53,7 @@ class sfWebResponse extends sfResponse
         '305' => 'Use Proxy',
         '306' => '(Unused)',
         '307' => 'Temporary Redirect',
+        '308' => 'Permanent Redirect',
         '400' => 'Bad Request',
         '401' => 'Unauthorized',
         '402' => 'Payment Required',


### PR DESCRIPTION
Using a HTTP status code [308](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#308) on a redirect in an action, such as `$this->redirect('@homepage', 308);` results in a warning about accessing a non-existend array key 308.

Providing the fallback status text fixes this issue