### PR TITLE
Fix I18n filterGet returning wrong culture after connection clear()

### DIFF
--- a/lib/plugins/sfDoctrinePlugin/lib/record/sfDoctrineRecordI18nFilter.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/record/sfDoctrineRecordI18nFilter.class.php
@@ -46,12 +46,19 @@ class sfDoctrineRecordI18nFilter extends Doctrine_Record_Filter
     public function filterGet(Doctrine_Record $record, $name)
     {
         $culture = sfDoctrineRecord::getDefaultCulture();
-        if (isset($record['Translation'][$culture]) && '' != $record['Translation'][$culture][$name]) {
-            return $record['Translation'][$culture][$name];
+
+        // Access Translation relation explicitly to trigger lazy loading.
+        // PHP's isset() with chained array access like isset($record['Translation'][$culture])
+        // does not trigger __get() on the intermediate $record['Translation'] access,
+        // causing the check to incorrectly return false on first access after clear().
+        $translation = $record['Translation'];
+
+        if (isset($translation[$culture]) && '' != $translation[$culture][$name]) {
+            return $translation[$culture][$name];
         }
 
         $defaultCulture = sfConfig::get('sf_default_culture');
 
-        return $record['Translation'][$defaultCulture][$name];
+        return $translation[$defaultCulture][$name];
     }
 }


### PR DESCRIPTION
## Problem

When changing the culture mid-request (e.g., to send an email in a user's preferred language), `filterGet()` returns translations in the wrong culture after calling `Doctrine_Connection::clear()`.

## Root Cause

PHP's `isset()` with chained array access like:
```php
isset($record['Translation'][$culture])
```
does **not** trigger `__get()` on the intermediate `$record['Translation']` access.

This means the Translation relation is never lazy-loaded, causing `isset()` to incorrectly return `false`. The method then falls back to `sf_default_culture` instead of the requested culture.

## Steps to Reproduce

```php
// 1. Load record and access translated field (triggers lazy load in culture A)
sfDoctrineRecord::setDefaultCulture('de');
$record = MyTable::getInstance()->find(1);
$title = $record->getTitle(); // Returns German

// 2. Clear the identity map
Doctrine_Manager::getInstance()->getCurrentConnection()->clear();

// 3. Change culture
sfDoctrineRecord::setDefaultCulture('fr');

// 4. Load fresh record and access translated field
$record2 = MyTable::getInstance()->find(1);
$title2 = $record2->getTitle();

// BUG: Returns German instead of French!
```

## Solution

Explicitly assign `$record['Translation']` to a variable before the `isset()` check. This triggers proper lazy loading of the Translation relation:

```php
$translation = $record['Translation'];  // Triggers lazy loading
if (isset($translation[$culture]) && '' != $translation[$culture][$name]) {
    return $translation[$culture][$name];
}
```

## Real-World Impact

This bug commonly affects applications that:
- Send emails in a user's preferred language during a request
- Process batch operations with different user cultures
- Switch cultures after clearing Doctrine's identity map

## Testing

The fix has been tested with multiple scenarios:
- No reload after culture change
- `refresh(true)` without `clear()`
- `refresh(true)` with `clear()`
- `find()` with `clear()`
- `find()` with `clear()` + `setDefaultCulture()`

All scenarios now correctly return translations in the target culture.