### PR TITLE
⚠️ [BC-Break] Require ext-mbstring; replace utf8_encode in lime JUnit reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 xx/xx/xxxx: Version 1.5.xx
 --------------------------
+* ⚠️ [BC-Break] Require ext-mbstring; replace deprecated utf8_encode() in lime JUnit reporter by @JohannesTyra in #395
 
 26/12/2025: Version 1.5.24
 --------------------------

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "require": {
         "php" : "^7.4 || ^8.1",
+        "ext-mbstring": "*",
         "friendsofsymfony1/swiftmailer": "^5.4.13 || ^6.2.5"
     },
     "require-dev": {

--- a/lib/vendor/lime/lime.php
+++ b/lib/vendor/lime/lime.php
@@ -103,7 +103,7 @@ class lime_test
       foreach ($result['tests'] as $test)
       {
         $testsuite->appendChild($testcase = $dom->createElement('testcase'));
-        $testcase->setAttribute('name', utf8_encode($test['message']));
+        $testcase->setAttribute('name', mb_convert_encoding($test['message'], 'UTF-8', 'ISO-8859-1'));
         $testcase->setAttribute('file', $test['file']);
         $testcase->setAttribute('line', $test['line']);
         $testcase->setAttribute('assertions', 1);


### PR DESCRIPTION
## Summary

`utf8_encode()` has been deprecated since PHP 8.2. The lime JUnit reporter calls it on test names at `lib/vendor/lime/lime.php:106`:

```php
$testcase->setAttribute('name', utf8_encode($test['message']));
```

Switch to the documented migration path `mb_convert_encoding($s, 'UTF-8', 'ISO-8859-1')`.

PR #393 added PHP 8.5 support and did touch `lime.php`, but only swapped `(boolean)` for `(bool)` at line 169 — the `utf8_encode` call at line 106 was left in place.

## Verification

Under PHP 8.4.7:
```
Function utf8_encode() is deprecated since 8.2, visit the php.net documentation for various alternatives
```

## Test plan
- [ ] Existing test suite passes on the 8.4/8.5 CI matrix
- [ ] JUnit reporter output is byte-identical for ASCII test names (the common case) and unchanged Latin-1-encoded for any high-bit input