### PR TITLE
PHP 8.4: register session save handler as a SessionHandlerInterface object

### DIFF
--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -189,6 +189,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
 /**
  * Adapts an sfDatabaseSessionStorage to the SessionHandlerInterface required by
  * PHP 8.4's session_set_save_handler().
+ *
  * See https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#session_set_save_handler
  *
  * This must be a separate object rather than having sfDatabaseSessionStorage

--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -63,14 +63,9 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
         }
 
         // use this object as the session handler
-        session_set_save_handler(
-            [$this, 'sessionOpen'],
-            [$this, 'sessionClose'],
-            [$this, 'sessionRead'],
-            [$this, 'sessionWrite'],
-            [$this, 'sessionDestroy'],
-            [$this, 'sessionGC']
-        );
+        // PHP 8.4: the 6-callback form of session_set_save_handler() is deprecated.
+        // Register a SessionHandlerInterface object instead (see adapter below).
+        session_set_save_handler(new sfDatabaseSessionHandler($this), true);
 
         // start our session
         session_start();
@@ -188,5 +183,69 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
         $this->sessionRead($newId);
 
         return $this->sessionWrite($newId, $this->sessionRead($currentId));
+    }
+}
+
+/**
+ * Adapts an sfDatabaseSessionStorage to the SessionHandlerInterface required by
+ * PHP 8.4's session_set_save_handler().
+ *
+ * This must be a separate object rather than having sfDatabaseSessionStorage
+ * implement the interface itself: sfSessionStorage already defines read()/write()
+ * for symfony's attribute storage ($_SESSION[$key]), which collide with the
+ * interface's read()/write() save-handler methods. The adapter delegates to the
+ * storage's sessionOpen/sessionClose/sessionRead/sessionWrite/sessionDestroy/sessionGC.
+ *
+ * #[\ReturnTypeWillChange] is required: SessionHandlerInterface declares tentative
+ * return types, and the legacy sessionXxx() methods return loosely-typed values
+ * (e.g. sessionGC() returns bool, not int) we must preserve unchanged.
+ *
+ * Defined in this file (not its own) so it is always available wherever the core
+ * autoloader has loaded sfDatabaseSessionStorage; it is only referenced from above.
+ */
+class sfDatabaseSessionHandler implements SessionHandlerInterface
+{
+    /** @var sfDatabaseSessionStorage */
+    private $storage;
+
+    public function __construct(sfDatabaseSessionStorage $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function open($path, $name)
+    {
+        return $this->storage->sessionOpen($path, $name);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function close()
+    {
+        return $this->storage->sessionClose();
+    }
+
+    #[\ReturnTypeWillChange]
+    public function read($id)
+    {
+        return $this->storage->sessionRead($id);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function write($id, $data)
+    {
+        return $this->storage->sessionWrite($id, $data);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function destroy($id)
+    {
+        return $this->storage->sessionDestroy($id);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function gc($max_lifetime)
+    {
+        return $this->storage->sessionGC($max_lifetime);
     }
 }

--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -197,9 +197,14 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
  * interface's read()/write() save-handler methods. The adapter delegates to the
  * storage's sessionOpen/sessionClose/sessionRead/sessionWrite/sessionDestroy/sessionGC.
  *
- * #[\ReturnTypeWillChange] is required: SessionHandlerInterface declares tentative
- * return types, and the legacy sessionXxx() methods return loosely-typed values
- * (e.g. sessionGC() returns bool, not int) we must preserve unchanged.
+ * Parameter and return types follow SessionHandlerInterface as closely as the
+ * library's minimum PHP (7.4) allows: scalar parameter types and covariant scalar
+ * return types (bool/string/int) are declared, which removes the need for
+ * #[\ReturnTypeWillChange]. The interface's read(): string|false and gc(): int|false
+ * union return types cannot be declared on 7.4 (union types are 8.0+), so the
+ * covariant string / int are used — both are subtypes of the tentative types, so no
+ * deprecation is emitted on 8.x. sessionGC() returns bool in every storage subclass,
+ * so gc() casts it to int to honour the interface's integer return.
  *
  * Defined in this file (not its own) so it is always available wherever the core
  * autoloader has loaded sfDatabaseSessionStorage; it is only referenced from above.
@@ -213,39 +218,33 @@ class sfDatabaseSessionHandler implements SessionHandlerInterface
         $this->storage = $storage;
     }
 
-    #[\ReturnTypeWillChange]
-    public function open($path, $name)
+    public function open(string $path, string $name): bool
     {
         return $this->storage->sessionOpen($path, $name);
     }
 
-    #[\ReturnTypeWillChange]
-    public function close()
+    public function close(): bool
     {
         return $this->storage->sessionClose();
     }
 
-    #[\ReturnTypeWillChange]
-    public function read($id)
+    public function read(string $id): string
     {
         return $this->storage->sessionRead($id);
     }
 
-    #[\ReturnTypeWillChange]
-    public function write($id, $data)
+    public function write(string $id, string $data): bool
     {
         return $this->storage->sessionWrite($id, $data);
     }
 
-    #[\ReturnTypeWillChange]
-    public function destroy($id)
+    public function destroy(string $id): bool
     {
         return $this->storage->sessionDestroy($id);
     }
 
-    #[\ReturnTypeWillChange]
-    public function gc($max_lifetime)
+    public function gc(int $max_lifetime): int
     {
-        return $this->storage->sessionGC($max_lifetime);
+        return (int) $this->storage->sessionGC($max_lifetime);
     }
 }

--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -189,6 +189,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
 /**
  * Adapts an sfDatabaseSessionStorage to the SessionHandlerInterface required by
  * PHP 8.4's session_set_save_handler().
+ * See https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#session_set_save_handler
  *
  * This must be a separate object rather than having sfDatabaseSessionStorage
  * implement the interface itself: sfSessionStorage already defines read()/write()
@@ -205,8 +206,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
  */
 class sfDatabaseSessionHandler implements SessionHandlerInterface
 {
-    /** @var sfDatabaseSessionStorage */
-    private $storage;
+    private sfDatabaseSessionStorage $storage;
 
     public function __construct(sfDatabaseSessionStorage $storage)
     {

--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -198,14 +198,12 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
  * interface's read()/write() save-handler methods. The adapter delegates to the
  * storage's sessionOpen/sessionClose/sessionRead/sessionWrite/sessionDestroy/sessionGC.
  *
- * Parameter and return types follow SessionHandlerInterface as closely as the
- * library's minimum PHP (7.4) allows: scalar parameter types and covariant scalar
- * return types (bool/string/int) are declared, which removes the need for
- * #[\ReturnTypeWillChange]. The interface's read(): string|false and gc(): int|false
- * union return types cannot be declared on 7.4 (union types are 8.0+), so the
- * covariant string / int are used — both are subtypes of the tentative types, so no
- * deprecation is emitted on 8.x. sessionGC() returns bool in every storage subclass,
- * so gc() casts it to int to honour the interface's integer return.
+ * The save-handler methods are intentionally left untyped with #[\ReturnTypeWillChange]:
+ * the library still supports PHP 7.4, where the internal SessionHandlerInterface has
+ * untyped parameters. Declaring parameter/return types here narrows that contract and
+ * raises an "incompatible declaration" warning that breaks the test suite on 7.4 (8.x,
+ * which added the types to the interface, is fine). #[\ReturnTypeWillChange] suppresses
+ * the 8.x tentative-return-type notice and parses as a harmless comment on 7.4.
  *
  * Defined in this file (not its own) so it is always available wherever the core
  * autoloader has loaded sfDatabaseSessionStorage; it is only referenced from above.
@@ -219,33 +217,39 @@ class sfDatabaseSessionHandler implements SessionHandlerInterface
         $this->storage = $storage;
     }
 
-    public function open(string $path, string $name): bool
+    #[\ReturnTypeWillChange]
+    public function open($path, $name)
     {
         return $this->storage->sessionOpen($path, $name);
     }
 
-    public function close(): bool
+    #[\ReturnTypeWillChange]
+    public function close()
     {
         return $this->storage->sessionClose();
     }
 
-    public function read(string $id): string
+    #[\ReturnTypeWillChange]
+    public function read($id)
     {
         return $this->storage->sessionRead($id);
     }
 
-    public function write(string $id, string $data): bool
+    #[\ReturnTypeWillChange]
+    public function write($id, $data)
     {
         return $this->storage->sessionWrite($id, $data);
     }
 
-    public function destroy(string $id): bool
+    #[\ReturnTypeWillChange]
+    public function destroy($id)
     {
         return $this->storage->sessionDestroy($id);
     }
 
-    public function gc(int $max_lifetime): int
+    #[\ReturnTypeWillChange]
+    public function gc($max_lifetime)
     {
-        return (int) $this->storage->sessionGC($max_lifetime);
+        return $this->storage->sessionGC($max_lifetime);
     }
 }


### PR DESCRIPTION
## Problem

Under PHP 8.4, `sfDatabaseSessionStorage::initialize()` emits:

```
PHP Deprecated:  session_set_save_handler(): Providing individual callbacks instead of an object implementing SessionHandlerInterface is deprecated in .../lib/storage/sfDatabaseSessionStorage.class.php on line 66
```

PHP 8.4 deprecates the six-callback form of `session_set_save_handler()` in favour of passing an object implementing `SessionHandlerInterface`. This fires on every request served with a database session backend (e.g. `sfPDOSessionStorage`).

## Fix

`sfDatabaseSessionStorage` **cannot** implement `SessionHandlerInterface` directly: its parent `sfSessionStorage` already defines `read()`/`write()` for symfony's *attribute* storage (`$_SESSION[$key]`), which collide with the save-handler `read()`/`write()` and have different semantics.

So this adds a small `sfDatabaseSessionHandler` adapter that implements `SessionHandlerInterface` and delegates to the existing `sessionOpen` / `sessionClose` / `sessionRead` / `sessionWrite` / `sessionDestroy` / `sessionGC` methods. The handler is registered with `session_set_save_handler($handler, true)`.

`#[\ReturnTypeWillChange]` is used on the adapter methods because `SessionHandlerInterface` declares tentative return types and the legacy `sessionXxx()` methods return loosely-typed values that must be preserved unchanged (e.g. `sessionGC()` returns `bool`, not `int`).

The adapter is defined in the same file as `sfDatabaseSessionStorage` so it is always available wherever the core autoloader has loaded that class; it is only referenced from within `initialize()`.

## Behaviour

No behavioural change. Verified on PHP 8.4.21 by driving a full session lifecycle through the adapter (`open` → `read` → `gc` → `write` → `close`): correct delegation, **no deprecation, no TypeError**. Confirmed the legacy six-callback form still reproduces the deprecation and that omitting `#[\ReturnTypeWillChange]` produces tentative-return-type notices.