### PR TITLE
Fix htmlspecialchars() deprecation on null parameter

### DIFF
--- a/lib/validator/sfValidatorError.class.php
+++ b/lib/validator/sfValidatorError.class.php
@@ -106,7 +106,7 @@ class sfValidatorError extends Exception implements Serializable
                 continue;
             }
 
-            $arguments["%{$key}%"] = htmlspecialchars($value, ENT_QUOTES, sfValidatorBase::getCharset());
+            $arguments["%{$key}%"] = htmlspecialchars((string) $value, ENT_QUOTES, sfValidatorBase::getCharset());
         }
 
         return $arguments;


### PR DESCRIPTION
This fixes a PHP 8.1+ deprecation warning in`sfValidatorError::getArguments()` when a validation error argument is
`null`.

This can occur, for example, with `sfValidatorSchemaCompare`: a field validation failure produces a `null` cleaned value, which the post-validator passes to `htmlspecialchars()` as an error argument.

Example:
```php
<?php

require __DIR__.'/vendor/autoload.php';

$schema = new sfValidatorSchema([
    'password' => new sfValidatorString(['min_length' => 8]),
    'password_again' => new sfValidatorString(),
]);

$schema->setPostValidator(
    new sfValidatorSchemaCompare(
        'password',
        sfValidatorSchemaCompare::EQUAL,
        'password_again',
    ),
);

try {
    // The first field fails validation and its cleaned value becomes null
    $schema->clean([
        'password' => 'short',
        'password_again' => 'short',
    ]);
} catch (sfValidatorErrorSchema $error) {
    // Expected validation failure; the deprecation is the bug
}
``` 